### PR TITLE
add support for `{placeholder:matches(regex)}` and `${placeholder.extract(regex)}`

### DIFF
--- a/e2e/fixtures/regex-constraints-broken/konsistent.json
+++ b/e2e/fixtures/regex-constraints-broken/konsistent.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "ai-provider-stems",
+      "paths": "packages/{providerId:matches(^[a-z]+ai$)}/src/${providerId}-stem.ts",
+      "must": {
+        "exportConstants": ["${providerId.extract(^([a-z]+)ai$)}"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/regex-constraints-broken/packages/google/src/google-stem.ts
+++ b/e2e/fixtures/regex-constraints-broken/packages/google/src/google-stem.ts
@@ -1,0 +1,1 @@
+export const wrong = 'wrong';

--- a/e2e/fixtures/regex-constraints-broken/packages/mistralai/src/mistralai-stem.ts
+++ b/e2e/fixtures/regex-constraints-broken/packages/mistralai/src/mistralai-stem.ts
@@ -1,0 +1,1 @@
+export const mistral = 'mistral';

--- a/e2e/fixtures/regex-constraints-broken/packages/openai/src/openai-stem.ts
+++ b/e2e/fixtures/regex-constraints-broken/packages/openai/src/openai-stem.ts
@@ -1,0 +1,1 @@
+export const wrong = 'wrong';

--- a/e2e/fixtures/regex-constraints/konsistent.json
+++ b/e2e/fixtures/regex-constraints/konsistent.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "ai-provider-stems",
+      "paths": "packages/{providerId:matches(^[a-z]+ai$)}/src/${providerId}-stem.ts",
+      "must": {
+        "exportConstants": ["${providerId.extract(^([a-z]+)ai$)}"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/regex-constraints/packages/google/src/google-stem.ts
+++ b/e2e/fixtures/regex-constraints/packages/google/src/google-stem.ts
@@ -1,0 +1,1 @@
+export const wrong = 'wrong';

--- a/e2e/fixtures/regex-constraints/packages/mistralai/src/mistralai-stem.ts
+++ b/e2e/fixtures/regex-constraints/packages/mistralai/src/mistralai-stem.ts
@@ -1,0 +1,1 @@
+export const mistral = 'mistral';

--- a/e2e/fixtures/regex-constraints/packages/openai/src/openai-stem.ts
+++ b/e2e/fixtures/regex-constraints/packages/openai/src/openai-stem.ts
@@ -1,0 +1,1 @@
+export const open = 'open';

--- a/e2e/placeholder.test.ts
+++ b/e2e/placeholder.test.ts
@@ -1038,3 +1038,34 @@ describe('placeholder-constraints-broken fixture', () => {
     }
   });
 });
+
+describe('regex-constraints fixture', () => {
+  const cwd = resolve(fixturesDir, 'regex-constraints');
+
+  it('konsistent check exits 0 when matches() filters and extract() resolves correctly', async () => {
+    const result = await runCli({ args: ['check'], cwd });
+    expect(result.stdout).toContain('Checked 2 files');
+    expect(result.stdout).toContain('No violations found.');
+  });
+});
+
+describe('regex-constraints-broken fixture', () => {
+  const cwd = resolve(fixturesDir, 'regex-constraints-broken');
+
+  it('konsistent check exits 1 with the constant name produced by extract()', async () => {
+    try {
+      await runCli({ args: ['check'], cwd });
+      expect.fail('Expected check to exit with code 1');
+    } catch (err: unknown) {
+      const error = err as {
+        stdout: string;
+        stderr: string;
+        code: number;
+        status: number;
+      };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain('Missing export constant "open"');
+      expect(error.stdout).toContain('Found 1 error');
+    }
+  });
+});

--- a/packages/konsistent/src/core/constraints/matches.test.ts
+++ b/packages/konsistent/src/core/constraints/matches.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { validateMatchesConstraint } from './matches.js';
+
+describe('validateMatchesConstraint', () => {
+  it('returns true when value matches the regex', () => {
+    expect(
+      validateMatchesConstraint({ value: 'openai', arg: '^[a-z]+ai$' })
+    ).toBe(true);
+  });
+
+  it('returns false when value does not match the regex', () => {
+    expect(
+      validateMatchesConstraint({ value: 'google', arg: '^[a-z]+ai$' })
+    ).toBe(false);
+  });
+
+  it('returns true for partial matches when regex is not anchored', () => {
+    expect(validateMatchesConstraint({ value: 'openai-v2', arg: 'ai' })).toBe(
+      true
+    );
+  });
+
+  it('returns false when arg is undefined', () => {
+    expect(validateMatchesConstraint({ value: 'openai' })).toBe(false);
+  });
+
+  it('returns false when regex is invalid', () => {
+    expect(
+      validateMatchesConstraint({ value: 'openai', arg: '[invalid' })
+    ).toBe(false);
+  });
+
+  it('returns true for empty value matching an empty-allowing regex', () => {
+    expect(validateMatchesConstraint({ value: '', arg: '^$' })).toBe(true);
+  });
+
+  it('treats regex as case-sensitive by default', () => {
+    expect(
+      validateMatchesConstraint({ value: 'OpenAI', arg: '^[a-z]+ai$' })
+    ).toBe(false);
+  });
+});

--- a/packages/konsistent/src/core/constraints/matches.ts
+++ b/packages/konsistent/src/core/constraints/matches.ts
@@ -1,0 +1,16 @@
+export function validateMatchesConstraint(opts: {
+  value: string;
+  arg?: string;
+}): boolean {
+  const { value, arg } = opts;
+  if (arg === undefined) {
+    return false;
+  }
+  let regex: RegExp;
+  try {
+    regex = new RegExp(arg);
+  } catch {
+    return false;
+  }
+  return regex.test(value);
+}

--- a/packages/konsistent/src/core/path-matcher.test.ts
+++ b/packages/konsistent/src/core/path-matcher.test.ts
@@ -35,6 +35,12 @@ describe('hasPlaceholders', () => {
   it('returns true for patterns with constrained placeholders', () => {
     expect(hasPlaceholders('packages/{name:segments(2)}/src')).toBe(true);
   });
+
+  it('returns true for patterns with regex constraint args', () => {
+    expect(hasPlaceholders('packages/{name:matches(^[a-z]+ai$)}/src')).toBe(
+      true
+    );
+  });
 });
 
 describe('patternToGlob', () => {
@@ -52,6 +58,10 @@ describe('patternToGlob', () => {
 
   it('replaces constrained placeholders with *', () => {
     expect(patternToGlob('{name:segments(2)}/src')).toBe('*/src');
+  });
+
+  it('replaces placeholders with regex constraint args with *', () => {
+    expect(patternToGlob('{name:matches(^[a-z]+ai$)}/src')).toBe('*/src');
   });
 });
 
@@ -276,6 +286,35 @@ describe('matchPaths', () => {
     expect(results).toHaveLength(1);
     expect(results[0].placeholders.pluginName.toString()).toBe('auth');
     expect(results[0].placeholders.modelName.toString()).toBe('user-role');
+  });
+
+  it('matches(regex) constraint filters values matching the regex', async () => {
+    const fs = createMockFileSystem({
+      globResults: new Map([
+        [
+          'packages/*',
+          ['packages/openai', 'packages/mistralai', 'packages/google'],
+        ],
+      ]),
+    });
+    const results = await matchPaths({
+      patterns: ['packages/{providerId:matches(^[a-z]+ai$)}'],
+      fileSystem: fs,
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0].placeholders.providerId.toString()).toBe('openai');
+    expect(results[1].placeholders.providerId.toString()).toBe('mistralai');
+  });
+
+  it('matches(regex) rejects values that do not match', async () => {
+    const fs = createMockFileSystem({
+      globResults: new Map([['packages/*', ['packages/google']]]),
+    });
+    const results = await matchPaths({
+      patterns: ['packages/{providerId:matches(^[a-z]+ai$)}'],
+      fileSystem: fs,
+    });
+    expect(results).toHaveLength(0);
   });
 
   it('glob wildcard segment alongside constrained placeholder', async () => {

--- a/packages/konsistent/src/core/path-matcher.ts
+++ b/packages/konsistent/src/core/path-matcher.ts
@@ -14,26 +14,27 @@ import { PlaceholderValue } from './placeholder.js';
  *   {name:constraint(arg)}  — placeholder with a constraint and an argument
  *
  * Examples:
- *   {providerId}            — captures "providerId", no constraint
- *   {modelKind:segments(2)} — captures "modelKind", constraint raw = "segments(2)"
+ *   {providerId}                     — captures "providerId", no constraint
+ *   {modelKind:segments(2)}          — captures "modelKind", constraint raw = "segments(2)"
+ *   {providerId:matches(^[a-z]+ai$)} — captures "providerId", constraint raw = "matches(^[a-z]+ai$)"
  *
  * Capture groups:
  *   [1] — placeholder name       (e.g. "modelKind")
  *   [2] — raw constraint string  (e.g. "segments(2)"), undefined when no constraint
  *
  * Breakdown:
- *   \{                                        — literal opening brace
- *   ([a-zA-Z][a-zA-Z0-9]*)                    — group 1: placeholder name (letter, then alphanumeric)
- *   (?:                                       — optional non-capturing group for constraint:
- *     :                                       —   literal colon separator
- *     ([a-zA-Z][a-zA-Z0-9]*                   —   group 2 start: constraint name
- *       (?:\([a-zA-Z0-9]+\))?                 —     optional parenthesised argument
- *     )                                       —   group 2 end
- *   )?                                        — end optional constraint group
- *   }                                         — literal closing brace
+ *   \{                                — literal opening brace
+ *   ([a-zA-Z][a-zA-Z0-9]*)            — group 1: placeholder name (letter, then alphanumeric)
+ *   (?:                               — optional non-capturing group for constraint:
+ *     :                               —   literal colon separator
+ *     ([a-zA-Z][a-zA-Z0-9]*           —   group 2 start: constraint name
+ *       (?:\([^}]*\))?                —     optional parenthesised argument (anything except `}`)
+ *     )                               —   group 2 end
+ *   )?                                — end optional constraint group
+ *   }                                 — literal closing brace
  */
 const PLACEHOLDER_REGEX =
-  /\{([a-zA-Z][a-zA-Z0-9]*)(?::([a-zA-Z][a-zA-Z0-9]*(?:\([a-zA-Z0-9]+\))?))?}/g;
+  /\{([a-zA-Z][a-zA-Z0-9]*)(?::([a-zA-Z][a-zA-Z0-9]*(?:\([^}]*\))?))?}/g;
 const TEMPLATE_IN_PATH_REGEX = /\$\{([a-zA-Z][a-zA-Z0-9]*)\}/g;
 const VALID_VALUE_REGEX = /^[a-zA-Z0-9_-]+$/;
 const ESCAPE_REGEX = /[.*+?^${}()|[\]\\]/g;

--- a/packages/konsistent/src/core/placeholder-constraint.test.ts
+++ b/packages/konsistent/src/core/placeholder-constraint.test.ts
@@ -26,6 +26,27 @@ describe('parsePlaceholderConstraint', () => {
     });
   });
 
+  it('parses constraint with regex-shaped argument', () => {
+    expect(parsePlaceholderConstraint('matches(^[a-z]+ai$)')).toEqual({
+      name: 'matches',
+      arg: '^[a-z]+ai$',
+    });
+  });
+
+  it('parses constraint with argument containing parens', () => {
+    expect(parsePlaceholderConstraint('extract(^([a-z]+)ai$)')).toEqual({
+      name: 'extract',
+      arg: '^([a-z]+)ai$',
+    });
+  });
+
+  it('parses constraint with empty argument', () => {
+    expect(parsePlaceholderConstraint('matches()')).toEqual({
+      name: 'matches',
+      arg: '',
+    });
+  });
+
   it('returns null for empty string', () => {
     expect(parsePlaceholderConstraint('')).toBeNull();
   });
@@ -54,6 +75,24 @@ describe('validatePlaceholderConstraint', () => {
       validatePlaceholderConstraint({
         value: 'chat',
         constraint: { name: 'segments', arg: '2' },
+      })
+    ).toBe(false);
+  });
+
+  it('dispatches to matches constraint and returns true on match', () => {
+    expect(
+      validatePlaceholderConstraint({
+        value: 'openai',
+        constraint: { name: 'matches', arg: '^[a-z]+ai$' },
+      })
+    ).toBe(true);
+  });
+
+  it('dispatches to matches constraint and returns false on no match', () => {
+    expect(
+      validatePlaceholderConstraint({
+        value: 'google',
+        constraint: { name: 'matches', arg: '^[a-z]+ai$' },
       })
     ).toBe(false);
   });

--- a/packages/konsistent/src/core/placeholder-constraint.ts
+++ b/packages/konsistent/src/core/placeholder-constraint.ts
@@ -1,3 +1,4 @@
+import { validateMatchesConstraint } from './constraints/matches.js';
 import { validateSegmentsConstraint } from './constraints/segments.js';
 
 export interface PlaceholderConstraint {
@@ -5,7 +6,7 @@ export interface PlaceholderConstraint {
   arg?: string;
 }
 
-const CONSTRAINT_REGEX = /^([a-zA-Z][a-zA-Z0-9]*)(?:\(([a-zA-Z0-9]+)\))?$/;
+const CONSTRAINT_REGEX = /^([a-zA-Z][a-zA-Z0-9]*)(?:\((.*)\))?$/;
 
 export function parsePlaceholderConstraint(
   raw: string
@@ -28,6 +29,8 @@ export function validatePlaceholderConstraint(opts: {
   switch (constraint.name) {
     case 'segments':
       return validateSegmentsConstraint({ value, arg: constraint.arg });
+    case 'matches':
+      return validateMatchesConstraint({ value, arg: constraint.arg });
     default:
       return true;
   }

--- a/packages/konsistent/src/core/placeholder.test.ts
+++ b/packages/konsistent/src/core/placeholder.test.ts
@@ -465,4 +465,52 @@ describe('PlaceholderValue', () => {
       ).toBe('cache');
     });
   });
+
+  describe('extract', () => {
+    it('returns first capture group when regex has subgroups', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai' }).extract('^([a-z]+)ai$')
+      ).toBe('open');
+    });
+
+    it('returns full match when regex has no subgroups', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai' }).extract('^[a-z]+ai$')
+      ).toBe('openai');
+    });
+
+    it('returns empty string when no match', () => {
+      expect(
+        new PlaceholderValue({ value: 'google' }).extract('^([a-z]+)ai$')
+      ).toBe('');
+    });
+
+    it('returns first capture group when regex has multiple subgroups', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai-chat' }).extract(
+          '^([a-z]+)-([a-z]+)$'
+        )
+      ).toBe('openai');
+    });
+
+    it('returns empty string when regex is invalid', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai' }).extract('[invalid')
+      ).toBe('');
+    });
+
+    it('supports partial matches when regex is not anchored', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai-v2' }).extract('([a-z]+)ai')
+      ).toBe('open');
+    });
+
+    it('returns empty string when match captures empty group', () => {
+      expect(
+        new PlaceholderValue({ value: 'openai' }).extract(
+          '^([a-z]*)open([a-z]+)$'
+        )
+      ).toBe('');
+    });
+  });
 });

--- a/packages/konsistent/src/core/placeholder.ts
+++ b/packages/konsistent/src/core/placeholder.ts
@@ -114,4 +114,18 @@ export class PlaceholderValue {
     // This is just one segment, so we can just lowercase it.
     return segment.toLowerCase();
   }
+
+  extract(pattern: string): string {
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern);
+    } catch {
+      return '';
+    }
+    const match = this.raw.match(regex);
+    if (!match) {
+      return '';
+    }
+    return match.length > 1 ? (match[1] ?? '') : match[0];
+  }
 }

--- a/packages/konsistent/src/core/template.test.ts
+++ b/packages/konsistent/src/core/template.test.ts
@@ -173,4 +173,36 @@ describe('resolveTemplate', () => {
     });
     expect(result).toBe('createGraphQL');
   });
+
+  it('resolves ${name.extract(regex)} to first capture group', () => {
+    const result = resolveTemplate({
+      template: '${name.extract(^([a-z]+)ai$)}-stem.ts',
+      placeholders: makePlaceholders({ name: 'openai' }),
+    });
+    expect(result).toBe('open-stem.ts');
+  });
+
+  it('resolves ${name.extract(regex)} to full match when no subgroups', () => {
+    const result = resolveTemplate({
+      template: '${name.extract(^[a-z]+ai$)}.ts',
+      placeholders: makePlaceholders({ name: 'openai' }),
+    });
+    expect(result).toBe('openai.ts');
+  });
+
+  it('resolves ${name.extract(regex)} to empty string when no match', () => {
+    const result = resolveTemplate({
+      template: '${name.extract(^([a-z]+)ai$)}.ts',
+      placeholders: makePlaceholders({ name: 'google' }),
+    });
+    expect(result).toBe('.ts');
+  });
+
+  it('preserves existing numeric-arg parsing', () => {
+    const result = resolveTemplate({
+      template: '${name.toNthSegment(0)}-x.ts',
+      placeholders: makePlaceholders({ name: 'openai-chat' }),
+    });
+    expect(result).toBe('openai-x.ts');
+  });
 });

--- a/packages/konsistent/src/core/template.ts
+++ b/packages/konsistent/src/core/template.ts
@@ -1,18 +1,6 @@
 import type { PlaceholderValue } from './placeholder.js';
 
-const TEMPLATE_REGEX = /\$\{(\w+)(?:\.(\w+)\((\d+)?\))?\}/g;
-
-const VALID_METHODS = new Set([
-  'toString',
-  'toPascalCase',
-  'toCamelCase',
-  'toKebabCase',
-  'toSnakeCase',
-  'toFlatCase',
-  'toNthSegment',
-  'toNthSegmentPascalCase',
-  'toNthSegmentCamelCase',
-]);
+const TEMPLATE_REGEX = /\$\{(\w+)(?:\.(\w+)\(([^}]*)\))?\}/g;
 
 export function resolveTemplate(opts: {
   template: string;
@@ -30,16 +18,29 @@ export function resolveTemplate(opts: {
       return placeholder.toString();
     }
 
-    if (!VALID_METHODS.has(method)) {
-      return original;
+    switch (method) {
+      case 'toString':
+        return placeholder.toString();
+      case 'toPascalCase':
+        return placeholder.toPascalCase();
+      case 'toCamelCase':
+        return placeholder.toCamelCase();
+      case 'toKebabCase':
+        return placeholder.toKebabCase();
+      case 'toSnakeCase':
+        return placeholder.toSnakeCase();
+      case 'toFlatCase':
+        return placeholder.toFlatCase();
+      case 'toNthSegment':
+        return placeholder.toNthSegment(Number(arg));
+      case 'toNthSegmentPascalCase':
+        return placeholder.toNthSegmentPascalCase(Number(arg));
+      case 'toNthSegmentCamelCase':
+        return placeholder.toNthSegmentCamelCase(Number(arg));
+      case 'extract':
+        return placeholder.extract(arg);
+      default:
+        return original;
     }
-
-    if (arg !== undefined) {
-      return (placeholder as unknown as Record<string, (n: number) => string>)[
-        method
-      ](Number(arg));
-    }
-
-    return (placeholder as unknown as Record<string, () => string>)[method]();
   });
 }

--- a/skills/konsistent-config/SKILL.md
+++ b/skills/konsistent-config/SKILL.md
@@ -109,6 +109,18 @@ Placeholders become available as templates `${pkgName}` inside `must` predicates
 - `${name.toNthSegment(0)}` — `my-thing` → `my` (split by `-`, return nth segment)
 - `${name.toNthSegmentPascalCase(0)}` — `my-thing` → `My` (nth segment with PascalCase)
 - `${name.toNthSegmentCamelCase(0)}` — `my-thing` → `my` (nth segment with camelCase)
+- `${name.extract(regex)}` — `openai` with `^([a-z]+)ai$` → `open` (returns the first capture group, or the full match if the regex has no groups; empty string when there is no match)
+
+The argument inside `(...)` is taken verbatim — no quotes around the regex. The argument may not contain `}` (use repetition like `\d\d?` instead of `\d{1,2}` if you need quantifiers).
+
+### Path Placeholder Constraints
+
+Path placeholders accept inline constraints with the syntax `{name:constraint(arg)}`. Constraints filter which captured values are considered — paths whose extracted value fails a constraint are skipped, the rule does not apply to them.
+
+- `{name:segments(n)}` — value must split into exactly `n` word segments (split by `-`, `_`, or camelCase boundaries). Example: `{modelKind:segments(2)}` matches `chat-language` but not `chat` or `chat-language-model`.
+- `{name:matches(regex)}` — value must match the JavaScript regex (case-sensitive, unanchored unless you anchor it). Example: `{providerId:matches(^[a-z]+ai$)}` matches `openai` and `mistralai` but not `google`.
+
+Constraints only apply to placeholders inside the path pattern (`{...}`), not to template substitutions (`${...}`). The argument inside `(...)` is taken verbatim — no surrounding quotes; the argument may not contain `}`.
 
 ### Path Negation
 


### PR DESCRIPTION
This allows for much more sophisticated matching and parsing of dynamic placeholders in path segments.
