### PR TITLE
add support for `--config-package` flag

### DIFF
--- a/docs/guides/authoring-reusable-conventions.md
+++ b/docs/guides/authoring-reusable-conventions.md
@@ -4,6 +4,8 @@ This guide walks you through publishing a package of reusable conventions that o
 
 For the consumer-facing reference (how a `konsistent.json` declares `conventionSources` and references your package), see [reusable-conventions.md](../reference/reusable-conventions.md).
 
+> **Reusable conventions vs. shared full configs.** This guide covers packages that ship *individual* conventions consumed via `conventionSources` — the artifact has the `ReusableConventionsPackageV1` shape and is exposed at `exports["./konsistent"]`. A different pattern is shipping a *full* `konsistent.json` (the `ConfigV1` shape) that consumers load via `konsistent --config-package <pkg>`. For that, drop a `konsistent.json` at the package's `dist/` (or the package root, or a path declared via the `package.json` `"konsistent"` field). See [cli.md](../reference/cli.md#flags) for `--config-package`.
+
 ## What you ship
 
 A reusable-conventions package ships a single JSON artifact at a fixed exports condition. The JSON has a `conventionSpecVersion: "v1"` literal and a `conventions: ReusableConvention[]` array. Consumers find it via:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,7 @@ Loads `konsistent.json`, runs every convention against the codebase, and reports
 
 ```bash
 konsistent check
+konsistent check --config-package @acme/shared-conventions
 konsistent check --format=json --max-diagnostics=1000
 konsistent check --error-on-warnings --diagnostic-level error
 ```
@@ -30,6 +31,7 @@ konsistent check --error-on-warnings --diagnostic-level error
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--config-path <path>` | string | `konsistent.json` (project root) | Path to the config file |
+| `--config-package <pkg>` | string | — | NPM package name to load `konsistent.json` from. Resolved from the consuming project's `node_modules`. Mutually exclusive with `--config-path` |
 | `--format <format>` | `default` \| `json` \| `github` \| `markdown` | `default` (auto-detects `github` in CI) | Output format |
 | `--verbose` | boolean | `false` | Show execution time and expanded details |
 | `--max-diagnostics <n>` | string (parsed as integer) | `100` | Maximum diagnostics to print before truncating |
@@ -49,9 +51,12 @@ Parses and validates `konsistent.json` against the schema without running any ch
 ```bash
 konsistent validate
 konsistent validate --config-path=path/to/konsistent.json
+konsistent validate --config-package @acme/shared-conventions
 ```
 
 Exits `0` and prints `Configuration is valid.` on success. Exits `1` with a Zod validation error on failure.
+
+`validate` accepts the same `--config-path` and `--config-package` flags as `check` (see the table above).
 
 ## Output formats
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # konsistent.json
 
-The `konsistent.json` file declares the structural conventions the CLI enforces. By default it lives at the project root; use `--config-path` to put it elsewhere.
+The `konsistent.json` file declares the structural conventions the CLI enforces. By default it lives at the project root; use `--config-path` to put it elsewhere, or `--config-package <pkg>` to load it from an installed npm package (see [cli.md](./cli.md#flags)).
 
 ## Top-level shape
 

--- a/e2e/fixtures/config-package-consumer/package.json
+++ b/e2e/fixtures/config-package-consumer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "konsistent-fixture-config-package-consumer",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@konsistent-test/config-package-source": "workspace:*",
+    "@konsistent/common-conventions": "workspace:*",
+    "konsistent": "workspace:*"
+  }
+}

--- a/e2e/fixtures/config-package-source/konsistent.json
+++ b/e2e/fixtures/config-package-source/konsistent.json
@@ -1,0 +1,4 @@
+{
+  "version": "v1",
+  "conventions": []
+}

--- a/e2e/fixtures/config-package-source/package.json
+++ b/e2e/fixtures/config-package-source/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@konsistent-test/config-package-source",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "files": ["dist"]
+}

--- a/e2e/fixtures/config-package-source/package.json
+++ b/e2e/fixtures/config-package-source/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "files": ["dist"]
+  "files": ["konsistent.json"]
 }

--- a/e2e/placeholder.test.ts
+++ b/e2e/placeholder.test.ts
@@ -536,6 +536,105 @@ describe("--config-path flag", () => {
   });
 });
 
+describe("--config-package flag", () => {
+  const cwd = resolve(fixturesDir, "config-package-consumer");
+
+  it("loads config from a package's dist folder via check", async () => {
+    await expect(
+      runCli({
+        args: [
+          "check",
+          "--config-package",
+          "@konsistent-test/config-package-source",
+        ],
+        cwd,
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("loads config from a package's dist folder via validate", async () => {
+    const { stdout } = await runCli({
+      args: [
+        "validate",
+        "--config-package",
+        "@konsistent-test/config-package-source",
+      ],
+      cwd,
+    });
+    expect(stdout).toContain("Configuration is valid");
+  });
+
+  it("exits 1 when the package is not installed", async () => {
+    try {
+      await runCli({
+        args: [
+          "check",
+          "--config-package",
+          "@konsistent-test/definitely-not-installed",
+        ],
+        cwd,
+      });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stderr: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stderr).toContain("not installed");
+      expect(error.stderr).toContain(
+        "@konsistent-test/definitely-not-installed"
+      );
+    }
+  });
+
+  it("exits 1 when the package contains no konsistent.json", async () => {
+    try {
+      await runCli({
+        args: ["check", "--config-package", "@konsistent/common-conventions"],
+        cwd,
+      });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stderr: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stderr).toContain("no konsistent.json found");
+    }
+  });
+
+  it("exits 1 when both --config-path and --config-package are passed", async () => {
+    try {
+      await runCli({
+        args: [
+          "check",
+          "--config-path",
+          "/some/path/konsistent.json",
+          "--config-package",
+          "@konsistent-test/config-package-source",
+        ],
+        cwd,
+      });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stderr: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stderr).toContain("--config-path");
+      expect(error.stderr).toContain("--config-package");
+    }
+  });
+
+  it("exits 1 when --config-package is path-form", async () => {
+    try {
+      await runCli({
+        args: ["check", "--config-package", "./local-pkg"],
+        cwd,
+      });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stderr: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stderr).toContain("looks like a filesystem path");
+    }
+  });
+});
+
 describe("--colors flag", () => {
   const cwd = resolve(fixturesDir, "plugin-system-broken-files");
 

--- a/e2e/placeholder.test.ts
+++ b/e2e/placeholder.test.ts
@@ -539,7 +539,7 @@ describe("--config-path flag", () => {
 describe("--config-package flag", () => {
   const cwd = resolve(fixturesDir, "config-package-consumer");
 
-  it("loads config from a package's dist folder via check", async () => {
+  it("loads config from a package via check", async () => {
     await expect(
       runCli({
         args: [
@@ -552,7 +552,7 @@ describe("--config-package flag", () => {
     ).resolves.not.toThrow();
   });
 
-  it("loads config from a package's dist folder via validate", async () => {
+  it("loads config from a package via validate", async () => {
     const { stdout } = await runCli({
       args: [
         "validate",

--- a/packages/konsistent/scripts/generate-schema.test.ts
+++ b/packages/konsistent/scripts/generate-schema.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
 import { describe, expect, it } from "vitest";
@@ -44,9 +44,16 @@ describe("konsistent.schema.json", () => {
     expect(predicatesSchema.additionalProperties).toBe(false);
   });
 
-  const passingFixtures = readdirSync(fixturesDir).filter(
-    (name) => name !== "invalid-config"
-  );
+  const passingFixtures = readdirSync(fixturesDir).filter((name) => {
+    if (name === "invalid-config") {
+      return false;
+    }
+    const fixturePath = resolve(fixturesDir, name);
+    if (!statSync(fixturePath).isDirectory()) {
+      return false;
+    }
+    return existsSync(resolve(fixturePath, "konsistent.json"));
+  });
 
   for (const fixture of passingFixtures) {
     it(`validates passing fixture: ${fixture}`, () => {

--- a/packages/konsistent/src/commands/check.ts
+++ b/packages/konsistent/src/commands/check.ts
@@ -20,6 +20,11 @@ const checkArgs = {
     type: "string" as const,
     description: "Path to konsistent.json config file",
   },
+  "config-package": {
+    type: "string" as const,
+    description:
+      "NPM package name to load konsistent.json from (alternative to --config-path)",
+  },
   format: {
     type: "string" as const,
     description: "Output format (default, json, github, markdown)",
@@ -82,10 +87,14 @@ export default defineCommand({
   },
   args: checkArgs,
   async run({ args }) {
-    const result = await loadConfig({ configPath: args["config-path"] });
+    const result = await loadConfig({
+      configPath: args["config-path"],
+      configPackage: args["config-package"],
+    });
     if (!result.success) {
       console.error(pc.red(result.error));
       process.exit(1);
+      return;
     }
 
     const diagnosticLevel =

--- a/packages/konsistent/src/commands/commands.test.ts
+++ b/packages/konsistent/src/commands/commands.test.ts
@@ -134,6 +134,51 @@ describe("validate command", () => {
   });
 });
 
+describe("--config-package CLI guards", () => {
+  it("check exits 1 when both --config-path and --config-package are passed", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+    await runCommand(checkCommand, {
+      rawArgs: ["--config-path", "/tmp/x.json", "--config-package", "@scope/p"],
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(message).toContain("--config-path");
+    expect(message).toContain("--config-package");
+  });
+
+  it("check exits 1 when --config-package is path-form", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+    await runCommand(checkCommand, {
+      rawArgs: ["--config-package", "./some/local/path"],
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(message).toContain("looks like a filesystem path");
+  });
+
+  it("validate exits 1 when --config-package is path-form", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+    await runCommand(validateCommand, {
+      rawArgs: ["--config-package", "/abs/path"],
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(message).toContain("looks like a filesystem path");
+  });
+});
+
 describe("resolveFormat", () => {
   it("returns explicit format when not default", () => {
     expect(resolveFormat({ format: "json" })).toBe("json");

--- a/packages/konsistent/src/commands/help.ts
+++ b/packages/konsistent/src/commands/help.ts
@@ -15,6 +15,7 @@ Commands:
 
 Check options:
   --config-path <path>       Path to konsistent.json config file
+  --config-package <pkg>     NPM package to load konsistent.json from (alternative to --config-path)
   --format <format>          Output format (default, json, github, markdown)
   --verbose                  Show execution time and expanded details
   --max-diagnostics <n>      Maximum number of diagnostics to report (default: 100)
@@ -24,6 +25,7 @@ Check options:
 
 Validate options:
   --config-path <path>    Path to konsistent.json config file
+  --config-package <pkg>  NPM package to load konsistent.json from (alternative to --config-path)
 
 Global options:
   --help, -h              Show help

--- a/packages/konsistent/src/commands/validate.ts
+++ b/packages/konsistent/src/commands/validate.ts
@@ -7,6 +7,11 @@ const validateArgs = {
     type: "string" as const,
     description: "Path to konsistent.json config file",
   },
+  "config-package": {
+    type: "string" as const,
+    description:
+      "NPM package name to load konsistent.json from (alternative to --config-path)",
+  },
 };
 
 export default defineCommand({
@@ -16,10 +21,14 @@ export default defineCommand({
   },
   args: validateArgs,
   async run({ args }) {
-    const result = await loadConfig({ configPath: args["config-path"] });
+    const result = await loadConfig({
+      configPath: args["config-path"],
+      configPackage: args["config-package"],
+    });
     if (!result.success) {
       console.error(pc.red(result.error));
       process.exit(1);
+      return;
     }
     console.log(pc.green("Configuration is valid."));
   },

--- a/packages/konsistent/src/config/loader.test.ts
+++ b/packages/konsistent/src/config/loader.test.ts
@@ -1,5 +1,7 @@
-import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadConfig } from "./loader.js";
 
 const fixturesDir = resolve(import.meta.dirname, "../../../../e2e/fixtures");
@@ -40,6 +42,218 @@ describe("loadConfig", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toContain("Invalid JSON");
+    }
+  });
+});
+
+describe("loadConfig --config-package", () => {
+  let tmpDir: string;
+  let consumerDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "konsistent-loader-package-"));
+    consumerDir = join(tmpDir, "consumer");
+    mkdirSync(consumerDir, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(consumerDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function setupPackage(opts: {
+    packageName: string;
+    packageJson?: Record<string, unknown>;
+    configAtRoot?: boolean;
+    configAtDist?: boolean;
+    configAtCustomPath?: string;
+  }): string {
+    const {
+      packageName,
+      packageJson,
+      configAtRoot,
+      configAtDist,
+      configAtCustomPath,
+    } = opts;
+
+    const pkgDir = join(consumerDir, "node_modules", ...packageName.split("/"));
+    mkdirSync(pkgDir, { recursive: true });
+
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify(
+        packageJson ?? { name: packageName, version: "0.0.0", type: "module" }
+      )
+    );
+
+    const validConfig = JSON.stringify({
+      version: "v1",
+      conventions: [],
+    });
+
+    if (configAtRoot) {
+      writeFileSync(join(pkgDir, "konsistent.json"), validConfig);
+    }
+    if (configAtDist) {
+      mkdirSync(join(pkgDir, "dist"), { recursive: true });
+      writeFileSync(join(pkgDir, "dist", "konsistent.json"), validConfig);
+    }
+    if (configAtCustomPath !== undefined) {
+      const target = join(pkgDir, configAtCustomPath);
+      mkdirSync(join(target, ".."), { recursive: true });
+      writeFileSync(target, validConfig);
+    }
+
+    return pkgDir;
+  }
+
+  it("loads konsistent.json from the package root", async () => {
+    setupPackage({ packageName: "@scope/root-config", configAtRoot: true });
+
+    const result = await loadConfig({ configPackage: "@scope/root-config" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.config.version).toBe("v1");
+    }
+  });
+
+  it("loads konsistent.json from the dist folder", async () => {
+    setupPackage({ packageName: "@scope/dist-config", configAtDist: true });
+
+    const result = await loadConfig({ configPackage: "@scope/dist-config" });
+    expect(result.success).toBe(true);
+  });
+
+  it("prefers dist/ over root when both are present", async () => {
+    const pkgDir = setupPackage({
+      packageName: "@scope/both",
+      configAtRoot: true,
+      configAtDist: true,
+    });
+
+    writeFileSync(
+      join(pkgDir, "konsistent.json"),
+      JSON.stringify({ version: "v1", conventions: [] })
+    );
+    writeFileSync(
+      join(pkgDir, "dist", "konsistent.json"),
+      JSON.stringify({
+        version: "v1",
+        conventions: [
+          {
+            name: "from-dist",
+            description: "Loaded from dist.",
+            paths: "src/*.ts",
+            must: { haveType: "file" },
+          },
+        ],
+      })
+    );
+
+    const result = await loadConfig({ configPackage: "@scope/both" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.config.conventions).toHaveLength(1);
+      expect(result.config.conventions[0].name).toBe("from-dist");
+    }
+  });
+
+  it('respects an explicit package.json "konsistent" field', async () => {
+    setupPackage({
+      packageName: "@scope/explicit-field",
+      packageJson: {
+        name: "@scope/explicit-field",
+        version: "0.0.0",
+        type: "module",
+        konsistent: "./build/my-config.json",
+      },
+      configAtCustomPath: "build/my-config.json",
+    });
+
+    const result = await loadConfig({
+      configPackage: "@scope/explicit-field",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("errors when the package is not installed", async () => {
+    const result = await loadConfig({
+      configPackage: "@konsistent-test/definitely-not-installed",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain(
+        "@konsistent-test/definitely-not-installed"
+      );
+      expect(result.error).toContain("not installed");
+    }
+  });
+
+  it("errors when the package contains no konsistent.json", async () => {
+    setupPackage({ packageName: "@scope/no-config" });
+
+    const result = await loadConfig({ configPackage: "@scope/no-config" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("no konsistent.json found");
+      expect(result.error).toContain("dist/konsistent.json");
+      expect(result.error).toContain("/konsistent.json");
+    }
+  });
+
+  it("errors when both --config-path and --config-package are passed", async () => {
+    const result = await loadConfig({
+      configPath: "/some/path/konsistent.json",
+      configPackage: "@scope/some-pkg",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("--config-path");
+      expect(result.error).toContain("--config-package");
+    }
+  });
+
+  it("rejects path-form values", async () => {
+    const result = await loadConfig({ configPackage: "./local-config" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("looks like a filesystem path");
+      expect(result.error).toContain("--config-path");
+    }
+  });
+
+  it("rejects absolute-path values", async () => {
+    const result = await loadConfig({ configPackage: "/abs/path" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("looks like a filesystem path");
+    }
+  });
+
+  it("rejects empty values", async () => {
+    const result = await loadConfig({ configPackage: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("empty");
+    }
+  });
+
+  it("rejects bare-package values with a subpath", async () => {
+    const result = await loadConfig({ configPackage: "lodash/fp" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("subpath");
+      expect(result.error).toContain('"lodash"');
+    }
+  });
+
+  it("rejects scoped-package values with a subpath", async () => {
+    const result = await loadConfig({ configPackage: "@scope/pkg/sub" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("subpath");
+      expect(result.error).toContain('"@scope/pkg"');
     }
   });
 });

--- a/packages/konsistent/src/config/loader.ts
+++ b/packages/konsistent/src/config/loader.ts
@@ -1,5 +1,11 @@
 import { readFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import {
+  classifySource,
+  extractPackageName,
+  findPackageDir,
+  pathExists,
+} from "./npm-resolver.js";
 import { validatePlaceholders } from "./placeholder-validator.js";
 import { expandReferences } from "./reference-expander.js";
 import type { ConfigV1 } from "./schema.js";
@@ -12,10 +18,34 @@ export type LoadConfigResult =
   | { success: true; config: ConfigV1 }
   | { success: false; error: string };
 
-export async function loadConfig(opts: {
+export interface LoadConfigOptions {
+  configPackage?: string;
   configPath?: string;
-}): Promise<LoadConfigResult> {
-  const filePath = opts.configPath ?? resolve(process.cwd(), CONFIG_FILENAME);
+}
+
+export async function loadConfig(
+  opts: LoadConfigOptions
+): Promise<LoadConfigResult> {
+  if (opts.configPath !== undefined && opts.configPackage !== undefined) {
+    return {
+      success: false,
+      error:
+        "Cannot use --config-path and --config-package together. Pass only one.",
+    };
+  }
+
+  let filePath: string;
+  if (opts.configPackage === undefined) {
+    filePath = opts.configPath ?? resolve(process.cwd(), CONFIG_FILENAME);
+  } else {
+    const resolved = await resolveConfigPackagePath({
+      configPackage: opts.configPackage,
+    });
+    if (!resolved.success) {
+      return resolved;
+    }
+    filePath = resolved.filePath;
+  }
 
   let raw: string;
   try {
@@ -76,4 +106,116 @@ export async function loadConfig(opts: {
       conventions: expansionResult.conventions,
     },
   };
+}
+
+type ResolvePackagePathResult =
+  | { success: true; filePath: string }
+  | { success: false; error: string };
+
+async function resolveConfigPackagePath(opts: {
+  configPackage: string;
+}): Promise<ResolvePackagePathResult> {
+  const { configPackage } = opts;
+
+  const kind = classifySource(configPackage);
+  if (kind === "empty") {
+    return {
+      success: false,
+      error: "--config-package value is empty. Pass an npm package name.",
+    };
+  }
+  if (kind === "path") {
+    return {
+      success: false,
+      error: `--config-package "${configPackage}" looks like a filesystem path. Use --config-path for filesystem paths.`,
+    };
+  }
+  if (!isBarePackageName(configPackage)) {
+    return {
+      success: false,
+      error: `--config-package "${configPackage}" includes a subpath. Pass only the package name (e.g. "${extractPackageName(configPackage)}").`,
+    };
+  }
+
+  const packageName = extractPackageName(configPackage);
+  const fromDir = process.cwd();
+  const pkgDir = await findPackageDir({ packageName, fromDir });
+  if (pkgDir === null) {
+    return {
+      success: false,
+      error: `--config-package "${configPackage}": package is not installed in any node_modules above ${fromDir}. Add it as a (dev) dependency.`,
+    };
+  }
+
+  const pkgJsonPath = join(pkgDir, "package.json");
+  const attempted: string[] = [];
+
+  let pkgJsonRaw: string;
+  try {
+    pkgJsonRaw = await readFile(pkgJsonPath, "utf-8");
+  } catch {
+    return {
+      success: false,
+      error: `--config-package "${configPackage}": could not read package.json at ${pkgJsonPath}.`,
+    };
+  }
+
+  let pkgJson: unknown;
+  try {
+    pkgJson = JSON.parse(pkgJsonRaw);
+  } catch {
+    return {
+      success: false,
+      error: `--config-package "${configPackage}": malformed package.json at ${pkgJsonPath}.`,
+    };
+  }
+
+  const explicit = readKonsistentField(pkgJson);
+  if (explicit !== null) {
+    const candidate = resolve(pkgDir, explicit);
+    attempted.push(`${candidate} (from package.json "konsistent" field)`);
+    if (await pathExists(candidate)) {
+      return { success: true, filePath: candidate };
+    }
+  }
+
+  const distCandidate = join(pkgDir, "dist", CONFIG_FILENAME);
+  attempted.push(distCandidate);
+  if (await pathExists(distCandidate)) {
+    return { success: true, filePath: distCandidate };
+  }
+
+  const rootCandidate = join(pkgDir, CONFIG_FILENAME);
+  attempted.push(rootCandidate);
+  if (await pathExists(rootCandidate)) {
+    return { success: true, filePath: rootCandidate };
+  }
+
+  return {
+    success: false,
+    error: `--config-package "${configPackage}": no konsistent.json found in package. Looked at:\n${attempted
+      .map((p) => `  - ${p}`)
+      .join("\n")}`,
+  };
+}
+
+function isBarePackageName(value: string): boolean {
+  if (value.startsWith("@")) {
+    return value.split("/").length === 2;
+  }
+  return !value.includes("/");
+}
+
+function readKonsistentField(pkgJson: unknown): string | null {
+  if (
+    typeof pkgJson === "object" &&
+    pkgJson !== null &&
+    Object.hasOwn(pkgJson, "konsistent")
+  ) {
+    const value = (pkgJson as { konsistent: unknown }).konsistent;
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
 }

--- a/packages/konsistent/src/config/npm-resolver.ts
+++ b/packages/konsistent/src/config/npm-resolver.ts
@@ -1,0 +1,52 @@
+import { stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+
+export type SourceKind = "path" | "npm" | "empty";
+
+export function classifySource(value: string): SourceKind {
+  if (value.trim() === "") {
+    return "empty";
+  }
+  if (value.startsWith(".") || isAbsolute(value)) {
+    return "path";
+  }
+  return "npm";
+}
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function extractPackageName(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    const parts = specifier.split("/");
+    return parts.slice(0, 2).join("/");
+  }
+  const slash = specifier.indexOf("/");
+  return slash === -1 ? specifier : specifier.slice(0, slash);
+}
+
+export async function findPackageDir(opts: {
+  packageName: string;
+  fromDir: string;
+}): Promise<string | null> {
+  const { packageName, fromDir } = opts;
+
+  let dir = resolvePath(fromDir);
+  for (;;) {
+    const candidate = join(dir, "node_modules", packageName);
+    if (await pathExists(join(candidate, "package.json"))) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}

--- a/packages/konsistent/src/config/source-resolver.ts
+++ b/packages/konsistent/src/config/source-resolver.ts
@@ -1,29 +1,21 @@
-import { readFile, stat } from "node:fs/promises";
-import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join, resolve as resolvePath } from "node:path";
 import {
   ReusableConventionsPackageV1Schema,
   type ReusableConventionV1,
 } from "@konsistent/convention";
 import { exports as resolveExportsField } from "resolve.exports";
+import {
+  classifySource,
+  extractPackageName,
+  findPackageDir,
+} from "./npm-resolver.js";
 
 export type SourceMap = Map<string, Map<string, ReusableConventionV1>>;
 
 export type ResolveSourcesResult =
   | { success: true; sourceMap: SourceMap }
   | { success: false; error: string };
-
-type SourceKind = "path" | "npm" | "empty";
-
-function classifySource(value: string): SourceKind {
-  if (value.trim() === "") {
-    return "empty";
-  }
-  // values starting with "." or "/" → path-form; else → npm specifier
-  if (value.startsWith(".") || isAbsolute(value)) {
-    return "path";
-  }
-  return "npm";
-}
 
 export async function resolveSources(opts: {
   conventionSources: Record<string, string>;
@@ -103,14 +95,16 @@ async function loadFromNpm(opts: {
 }): Promise<LoadResult> {
   const { prefix, specifier, configDir } = opts;
 
-  const pkgJsonPath = await findPackageJson({ specifier, fromDir: configDir });
-  if (pkgJsonPath === null) {
+  const packageName = extractPackageName(specifier);
+  const pkgDir = await findPackageDir({ packageName, fromDir: configDir });
+  if (pkgDir === null) {
     return {
       success: false,
       error: `Convention source "${prefix}" → "${specifier}": could not resolve npm package "${specifier}". The package may not be installed under the consumer's project.`,
     };
   }
 
+  const pkgJsonPath = join(pkgDir, "package.json");
   let pkgJsonRaw: string;
   try {
     pkgJsonRaw = await readFile(pkgJsonPath, "utf-8");
@@ -150,7 +144,6 @@ async function loadFromNpm(opts: {
     };
   }
 
-  const pkgDir = dirname(pkgJsonPath);
   const conventionsPath = resolvePath(pkgDir, resolved[0]);
 
   let raw: string;
@@ -169,45 +162,6 @@ async function loadFromNpm(opts: {
     locationLabel: conventionsPath,
     raw,
   });
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function findPackageJson(opts: {
-  specifier: string;
-  fromDir: string;
-}): Promise<string | null> {
-  const { specifier, fromDir } = opts;
-  const packageName = extractPackageName(specifier);
-
-  let dir = resolvePath(fromDir);
-  for (;;) {
-    const candidate = join(dir, "node_modules", packageName, "package.json");
-    if (await pathExists(candidate)) {
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      return null;
-    }
-    dir = parent;
-  }
-}
-
-function extractPackageName(specifier: string): string {
-  if (specifier.startsWith("@")) {
-    const parts = specifier.split("/");
-    return parts.slice(0, 2).join("/");
-  }
-  const slash = specifier.indexOf("/");
-  return slash === -1 ? specifier : specifier.slice(0, slash);
 }
 
 function parseAndValidate(opts: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,20 @@ importers:
         specifier: ^3
         version: 3.2.4(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  e2e/fixtures/config-package-consumer:
+    dependencies:
+      '@konsistent-test/config-package-source':
+        specifier: workspace:*
+        version: link:../config-package-source
+      '@konsistent/common-conventions':
+        specifier: workspace:*
+        version: link:../../../packages/common-conventions
+      konsistent:
+        specifier: workspace:*
+        version: link:../../../packages/konsistent
+
+  e2e/fixtures/config-package-source: {}
+
   e2e/fixtures/reusable-convention-merge-overrides-pkg:
     dependencies:
       '@konsistent/common-conventions':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
   - "e2e/fixtures/reusable-convention-merge-overrides-pkg"
   - "e2e/fixtures/reusable-convention-merge-overrides-pkg-broken"
   - "e2e/fixtures/reusable-convention-unknown-source"
+  - "e2e/fixtures/config-package-source"
+  - "e2e/fixtures/config-package-consumer"


### PR DESCRIPTION
The new `--config-package` flag allows the caller to point to another installed package. If so, `konsistent` will read the `konsistent.json` file from that package.

The package that includes the `konsistent.json` file can provide a pointer to where the file lives in its `package.json`, e.g. `"konsistent": "./build/my-config.json"`. Otherwise, `konsistent` will look for either `dist/konsistent.json` or `konsistent.json`.
