### PR TITLE
mark packages as public

### DIFF
--- a/packages/common-conventions/package.json
+++ b/packages/common-conventions/package.json
@@ -26,5 +26,8 @@
     "@types/node": "^24",
     "vitest": "^3",
     "zod": "^4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/convention/package.json
+++ b/packages/convention/package.json
@@ -40,5 +40,8 @@
     "tsx": "^4.21.0",
     "vitest": "^3",
     "zod": "^4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/konsistent/package.json
+++ b/packages/konsistent/package.json
@@ -39,5 +39,8 @@
     "tsup": "^8",
     "tsx": "^4.21.0",
     "vitest": "^3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Now that we have scoped packages, they require an explicit `publishConfig.access = 'public'`.
