### PR TITLE
fix reusable conventions to be allowed in inner must blocks

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -88,7 +88,7 @@ All listed predicates apply unconditionally to every matched path. See [predicat
 ]
 ```
 
-Each entry is a `MustBlock` that can have `if`, `for`, `excludeFiles`, `name`, and `description`. See [conditional-rules.md](./conditional-rules.md).
+Each entry is a `MustBlock` that can have `if`, `for`, `excludeFiles`, `name`, and `description`. See [conditional-rules.md](./conditional-rules.md). An entry may alternatively be a reusable-convention reference of the form `{ "use": "<vendor>/<name>", ...overrides }`, which expands into a `MustBlock` — see [reusable-conventions.md](./reusable-conventions.md#use-inside-a-parents-must).
 
 ## Severity
 

--- a/docs/reference/reusable-conventions.md
+++ b/docs/reference/reusable-conventions.md
@@ -86,6 +86,33 @@ Use this form when the reusable convention has no `paths` (so you must supply th
 
 Any entry that is neither a string nor has a `use` key is treated as a hand-written `Convention` and validated against the existing schema. See [configuration.md](./configuration.md). You can mix all three forms in the same `conventions[]` array.
 
+### `use` inside a parent's `must[]`
+
+A hand-written convention whose `must` is a `MustBlock[]` may also reference a reusable convention from inside the array — the entry takes the same `{ "use": "<vendor>/<name>", ...overrides }` shape, but expands into a single `MustBlock` rather than a full `Convention`.
+
+```json
+{
+  "version": "v1",
+  "conventionSources": {
+    "common": "./local-conventions.json"
+  },
+  "conventions": [
+    {
+      "name": "component-folder-shape",
+      "paths": ["src/components/{componentName}"],
+      "must": [
+        { "must": { "haveType": "directory" } },
+        { "use": "common/must-have-index" }
+      ]
+    }
+  ]
+}
+```
+
+Allowed override keys at this nesting level are every field a hand-written `MustBlock` exposes — `name`, `description`, `if`, `for`, `excludeFiles`, and `must`. Top-level-only fields (`paths`, `severity`) are not accepted at the use-site, and the referenced reusable convention must not declare them either: a reusable that ships `paths` or `severity` can only be referenced from the top level of `conventions[]`. Authors who want their reusable to be usable in both contexts should publish it without those fields.
+
+Override merge follows the same rules as the top-level `use` form: arrays replace, primitives replace, and `must` deep-merges with the inherited predicates.
+
 ## Merge semantics
 
 When you write `{ use: "<vendor>/<name>", ...overrides }`, `konsistent` deep-merges your overrides on top of the reusable convention with these rules:
@@ -171,6 +198,7 @@ All errors below are returned from `loadConfig()` as `{ success: false, error }`
 | Reusable-convention package fails schema validation | `Convention source "<prefix>" → "<specifier>": invalid reusable-convention package at <path>: <issues>` | The author shipped an invalid package; report upstream. |
 | Empty source value | `Convention source "<prefix>" has empty value.` | Supply a path or npm specifier. |
 | Placeholder used in `must` but not declared in `paths` | `Convention "<identifier>" references "${<placeholder>}" in <key>, but no entry of paths declares "{<placeholder>}".` | Either declare the placeholder in `paths`, or remove the unresolved template from `must`. |
+| `use` inside `must[]` points at a reusable that declares `paths`/`severity` | `Convention "<prefix>/<name>" referenced in conventions[<i>].must[<j>] declares top-level-only field(s) "<field>". Such conventions can only be referenced at the top level of conventions[]. Either remove the field(s) from the source convention, or move the reference out of must[].` | Drop `paths`/`severity` from the reusable, or reference it directly from `conventions[]`. |
 
 `<identifier>` in the placeholder error is the convention's `name`, the `<vendor>/<name>` reference, or `conventions[<i>]` — whichever was available.
 

--- a/e2e/fixtures/reusable-convention-must-block-ref-broken/konsistent.json
+++ b/e2e/fixtures/reusable-convention-must-block-ref-broken/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventionSources": {
+    "common": "./local-conventions.json"
+  },
+  "conventions": [
+    {
+      "name": "component-folder-shape",
+      "paths": ["src/components/{componentName}"],
+      "must": [
+        { "must": { "haveType": "directory" } },
+        { "use": "common/must-have-index" }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-must-block-ref-broken/local-conventions.json
+++ b/e2e/fixtures/reusable-convention-must-block-ref-broken/local-conventions.json
@@ -1,0 +1,12 @@
+{
+  "conventionSpecVersion": "v1",
+  "conventions": [
+    {
+      "name": "must-have-index",
+      "description": "Folder must contain an index.ts file.",
+      "must": {
+        "haveFiles": ["index.ts"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-must-block-ref-broken/src/components/Button/index.ts
+++ b/e2e/fixtures/reusable-convention-must-block-ref-broken/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export const Button = "button";

--- a/e2e/fixtures/reusable-convention-must-block-ref-broken/src/components/Card/Card.ts
+++ b/e2e/fixtures/reusable-convention-must-block-ref-broken/src/components/Card/Card.ts
@@ -1,0 +1,1 @@
+export const Card = "card";

--- a/e2e/fixtures/reusable-convention-must-block-ref/konsistent.json
+++ b/e2e/fixtures/reusable-convention-must-block-ref/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventionSources": {
+    "common": "./local-conventions.json"
+  },
+  "conventions": [
+    {
+      "name": "component-folder-shape",
+      "paths": ["src/components/{componentName}"],
+      "must": [
+        { "must": { "haveType": "directory" } },
+        { "use": "common/must-have-index" }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-must-block-ref/local-conventions.json
+++ b/e2e/fixtures/reusable-convention-must-block-ref/local-conventions.json
@@ -1,0 +1,12 @@
+{
+  "conventionSpecVersion": "v1",
+  "conventions": [
+    {
+      "name": "must-have-index",
+      "description": "Folder must contain an index.ts file.",
+      "must": {
+        "haveFiles": ["index.ts"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-must-block-ref/src/components/Button/index.ts
+++ b/e2e/fixtures/reusable-convention-must-block-ref/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export const Button = "button";

--- a/e2e/fixtures/reusable-convention-must-block-ref/src/components/Card/index.ts
+++ b/e2e/fixtures/reusable-convention-must-block-ref/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export const Card = "card";

--- a/e2e/reusable-conventions.test.ts
+++ b/e2e/reusable-conventions.test.ts
@@ -94,6 +94,41 @@ describe("reusable-convention-object-ref-broken fixture", () => {
   });
 });
 
+describe("reusable-convention-must-block-ref fixture", () => {
+  const cwd = resolve(fixturesDir, "reusable-convention-must-block-ref");
+
+  it("konsistent check exits 0 when a must[] use ref expands and component folders are valid", async () => {
+    await expect(runCli({ args: ["check"], cwd })).resolves.not.toThrow();
+  });
+
+  it("konsistent validate exits 0 with the nested use ref resolved", async () => {
+    const { stdout } = await runCli({ args: ["validate"], cwd });
+    expect(stdout).toContain("Configuration is valid");
+  });
+});
+
+describe("reusable-convention-must-block-ref-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "reusable-convention-must-block-ref-broken");
+
+  it("konsistent check exits 1 when a must[] use ref surfaces a missing-file violation", async () => {
+    try {
+      await runCli({ args: ["check"], cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as {
+        stdout: string;
+        stderr: string;
+        code: number;
+        status: number;
+      };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain("Missing required file");
+      expect(error.stdout).toContain("index.ts");
+      expect(error.stdout).toContain("must-have-index");
+    }
+  });
+});
+
 describe("reusable-convention-merge-overrides fixture", () => {
   const cwd = resolve(fixturesDir, "reusable-convention-merge-overrides");
 

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -682,328 +682,660 @@
                   {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "pattern": "^[a-z0-9-]+$"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "if": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "hasFile": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["hasFile"],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "placeholderSatisfies": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["placeholderSatisfies"],
-                              "additionalProperties": false
-                            }
-                          ]
-                        },
-                        "for": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "files": {
+                            "name": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "if": {
                               "anyOf": [
                                 {
-                                  "type": "string"
+                                  "type": "object",
+                                  "properties": {
+                                    "hasFile": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["hasFile"],
+                                  "additionalProperties": false
                                 },
                                 {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
+                                  "type": "object",
+                                  "properties": {
+                                    "placeholderSatisfies": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["placeholderSatisfies"],
+                                  "additionalProperties": false
                                 }
                               ]
-                            }
-                          },
-                          "required": ["files"],
-                          "additionalProperties": false
-                        },
-                        "excludeFiles": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "must": {
-                          "type": "object",
-                          "properties": {
-                            "haveType": {
-                              "type": "string",
-                              "enum": ["file", "directory"]
                             },
-                            "haveFiles": {
+                            "for": {
+                              "type": "object",
+                              "properties": {
+                                "files": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["files"],
+                              "additionalProperties": false
+                            },
+                            "excludeFiles": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               }
                             },
-                            "export": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
+                            "must": {
+                              "type": "object",
+                              "properties": {
+                                "haveType": {
+                                  "type": "string",
+                                  "enum": ["file", "directory"]
+                                },
+                                "haveFiles": {
+                                  "type": "array",
+                                  "items": {
                                     "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string"
-                                      },
-                                      "from": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
                                   }
-                                ]
-                              }
-                            },
-                            "exportTypes": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
+                                },
+                                "export": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
                                         "type": "string"
                                       },
-                                      "from": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
-                                  }
-                                ]
-                              }
-                            },
-                            "exportConstants": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string"
-                                      },
-                                      "from": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
-                                  }
-                                ]
-                              }
-                            },
-                            "exportFunctions": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string"
-                                      },
-                                      "receiveParamOfType": {
-                                        "type": "string"
-                                      },
-                                      "returnValueOfType": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
-                                  }
-                                ]
-                              }
-                            },
-                            "exportInterfaces": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string"
-                                      },
-                                      "extend": {
-                                        "anyOf": [
-                                          {
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
                                             "type": "string"
                                           },
-                                          {
-                                            "type": "object",
-                                            "properties": {
-                                              "type": {
-                                                "type": "string"
-                                              },
-                                              "allowOmissions": {
-                                                "type": "boolean"
-                                              }
-                                            },
-                                            "required": ["type"],
-                                            "additionalProperties": false
+                                          "from": {
+                                            "type": "string"
                                           }
-                                        ]
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
+                                    ]
                                   }
-                                ]
-                              }
-                            },
-                            "exportClasses": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
+                                },
+                                "exportTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
                                         "type": "string"
                                       },
-                                      "extend": {
-                                        "anyOf": [
-                                          {
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
                                             "type": "string"
                                           },
-                                          {
-                                            "type": "object",
-                                            "properties": {
-                                              "type": {
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportConstants": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportFunctions": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "receiveParamOfType": {
+                                            "type": "string"
+                                          },
+                                          "returnValueOfType": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportInterfaces": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "extend": {
+                                            "anyOf": [
+                                              {
                                                 "type": "string"
                                               },
-                                              "allowOmissions": {
-                                                "type": "boolean"
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "allowOmissions": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
                                               }
-                                            },
-                                            "required": ["type"],
-                                            "additionalProperties": false
+                                            ]
                                           }
-                                        ]
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportClasses": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
                                       },
-                                      "implement": {
-                                        "type": "array",
-                                        "items": {
-                                          "anyOf": [
-                                            {
-                                              "type": "string"
-                                            },
-                                            {
-                                              "type": "object",
-                                              "properties": {
-                                                "type": {
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "extend": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "allowOmissions": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          },
+                                          "implement": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
                                                   "type": "string"
                                                 },
-                                                "allowOmissions": {
-                                                  "type": "boolean"
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string"
+                                                    },
+                                                    "allowOmissions": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": ["type"],
+                                                  "additionalProperties": false
                                                 }
-                                              },
-                                              "required": ["type"],
-                                              "additionalProperties": false
+                                              ]
                                             }
-                                          ]
-                                        }
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
+                                    ]
                                   }
-                                ]
-                              }
-                            },
-                            "import": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
+                                },
+                                "import": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
                                         "type": "string"
                                       },
-                                      "from": {
-                                        "type": "string"
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
+                                    ]
                                   }
-                                ]
-                              }
-                            },
-                            "importTypes": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
+                                },
+                                "importTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
                                         "type": "string"
                                       },
-                                      "from": {
-                                        "type": "string"
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
                                       }
-                                    },
-                                    "required": ["name"],
-                                    "additionalProperties": false
+                                    ]
                                   }
-                                ]
-                              }
+                                }
+                              },
+                              "additionalProperties": false
                             }
                           },
+                          "required": ["must"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+$"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "if": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "hasFile": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["hasFile"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "placeholderSatisfies": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["placeholderSatisfies"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "for": {
+                              "type": "object",
+                              "properties": {
+                                "files": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["files"],
+                              "additionalProperties": false
+                            },
+                            "excludeFiles": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "must": {
+                              "type": "object",
+                              "properties": {
+                                "haveType": {
+                                  "type": "string",
+                                  "enum": ["file", "directory"]
+                                },
+                                "haveFiles": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "export": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportConstants": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportFunctions": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "receiveParamOfType": {
+                                            "type": "string"
+                                          },
+                                          "returnValueOfType": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportInterfaces": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "extend": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "allowOmissions": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "exportClasses": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "extend": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "allowOmissions": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          },
+                                          "implement": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string"
+                                                    },
+                                                    "allowOmissions": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": ["type"],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "import": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "importTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "from": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "use": {
+                              "type": "string",
+                              "pattern": "^[a-z0-9-]+\\/[a-z0-9-]+$"
+                            }
+                          },
+                          "required": ["use"],
                           "additionalProperties": false
                         }
-                      },
-                      "required": ["must"],
-                      "additionalProperties": false
+                      ]
                     }
                   }
                 ]

--- a/packages/konsistent/src/config/index.ts
+++ b/packages/konsistent/src/config/index.ts
@@ -2,12 +2,14 @@ export { loadConfig } from "./loader.js";
 export type {
   ConfigV1,
   ConventionV1,
+  MustBlockUseRefV1,
   MustBlockV1,
   MustPredicatesV1,
 } from "./schema.js";
 export {
   ConfigV1Schema,
   ConventionV1Schema,
+  MustBlockUseRefSchema,
   MustBlockV1Schema,
   MustPredicatesV1Schema,
 } from "./schema.js";

--- a/packages/konsistent/src/config/reference-expander.test.ts
+++ b/packages/konsistent/src/config/reference-expander.test.ts
@@ -473,6 +473,162 @@ describe("expandReferences", () => {
     }
   });
 
+  it("expands a use ref nested inside a hand-written must[]", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "needs-readme",
+          description: "Block requiring a README.md.",
+          must: { haveFiles: ["README.md"] },
+        },
+      ],
+    });
+
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [
+        { must: { haveType: "directory" } },
+        { use: "common/needs-readme" },
+      ],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const must = result.conventions[0]?.must;
+      expect(Array.isArray(must)).toBe(true);
+      if (Array.isArray(must)) {
+        expect(must).toHaveLength(2);
+        expect(must[1]).toEqual({
+          name: "needs-readme",
+          description: "Block requiring a README.md.",
+          must: { haveFiles: ["README.md"] },
+        });
+      }
+    }
+  });
+
+  it("deep-merges override.must onto the inherited predicates inside must[]", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "base-block",
+          description: "x",
+          must: { haveFiles: ["README.md"] },
+        },
+      ],
+    });
+
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [
+        {
+          use: "common/base-block",
+          for: { files: "{packageName}/index.ts" },
+          must: { exportTypes: ["Public"] },
+        },
+      ],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const must = result.conventions[0]?.must;
+      if (Array.isArray(must)) {
+        expect(must[0]).toEqual({
+          name: "base-block",
+          description: "x",
+          for: { files: "{packageName}/index.ts" },
+          must: { haveFiles: ["README.md"], exportTypes: ["Public"] },
+        });
+      }
+    }
+  });
+
+  it("errors when a must[] use ref points to a reusable that declares paths", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "with-paths",
+          description: "x",
+          paths: "src/*.ts",
+          must: { haveType: "file" },
+        },
+      ],
+    });
+
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [{ use: "common/with-paths" }],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("conventions[0].must[0]");
+      expect(result.error).toContain('"paths"');
+      expect(result.error).toContain("top-level-only");
+    }
+  });
+
+  it("errors when a must[] use ref points to a reusable that declares severity", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "with-severity",
+          description: "x",
+          severity: "warning",
+          must: { haveType: "file" },
+        },
+      ],
+    });
+
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [{ use: "common/with-severity" }],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('"severity"');
+    }
+  });
+
+  it("emits an unknown-source error scoped to conventions[i].must[j]", () => {
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [{ use: "missing/foo" }],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap: new Map(),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("conventions[0].must[0]");
+      expect(result.error).toContain('Unknown convention source "missing"');
+    }
+  });
+
   it("includes conventions.<i> in the path of Zod errors when the merged result is invalid", () => {
     const sourceMap = buildSourceMap({
       common: [

--- a/packages/konsistent/src/config/reference-expander.ts
+++ b/packages/konsistent/src/config/reference-expander.ts
@@ -1,4 +1,9 @@
-import type { ReusableConventionV1 } from "@konsistent/convention";
+import type {
+  MustBlockV1,
+  MustPredicatesV1,
+  ReusableConventionV1,
+} from "@konsistent/convention";
+import { MustBlockV1Schema } from "@konsistent/convention";
 import type { ConventionV1, RawConfigV1 } from "./schema.js";
 import { ConventionV1Schema } from "./schema.js";
 import type { SourceMap } from "./source-resolver.js";
@@ -51,12 +56,143 @@ export function expandReferences(opts: {
       continue;
     }
 
-    const handWritten = entry as ConventionV1;
-    expanded.push(handWritten);
-    identifiers.push(handWritten.name ?? `conventions[${i}]`);
+    const handWrittenResult = expandHandWritten({
+      entry: entry as ConventionV1 & {
+        must:
+          | MustPredicatesV1
+          | Array<MustBlockV1 | ({ use: string } & Record<string, unknown>)>;
+      },
+      index: i,
+      sourceMap,
+    });
+    if (!handWrittenResult.success) {
+      return handWrittenResult;
+    }
+    expanded.push(handWrittenResult.convention);
+    identifiers.push(handWrittenResult.convention.name ?? `conventions[${i}]`);
   }
 
   return { success: true, conventions: expanded, identifiers };
+}
+
+function expandHandWritten(opts: {
+  entry: ConventionV1 & {
+    must:
+      | MustPredicatesV1
+      | Array<MustBlockV1 | ({ use: string } & Record<string, unknown>)>;
+  };
+  index: number;
+  sourceMap: SourceMap;
+}):
+  | { success: true; convention: ConventionV1 }
+  | { success: false; error: string } {
+  const { entry, index, sourceMap } = opts;
+
+  if (!Array.isArray(entry.must)) {
+    return { success: true, convention: entry as ConventionV1 };
+  }
+
+  const resolvedBlocks: MustBlockV1[] = [];
+  for (let j = 0; j < entry.must.length; j++) {
+    const block = entry.must[j];
+    if (block && typeof block === "object" && Object.hasOwn(block, "use")) {
+      const useRef = block as { use: string } & Record<string, unknown>;
+      const expandedBlock = expandMustBlockUseReference({
+        entry: useRef,
+        conventionIndex: index,
+        blockIndex: j,
+        sourceMap,
+      });
+      if (!expandedBlock.success) {
+        return expandedBlock;
+      }
+      resolvedBlocks.push(expandedBlock.block);
+      continue;
+    }
+    resolvedBlocks.push(block as MustBlockV1);
+  }
+
+  return {
+    success: true,
+    convention: { ...entry, must: resolvedBlocks } as ConventionV1,
+  };
+}
+
+function expandMustBlockUseReference(opts: {
+  entry: { use: string } & Record<string, unknown>;
+  conventionIndex: number;
+  blockIndex: number;
+  sourceMap: SourceMap;
+}): { success: true; block: MustBlockV1 } | { success: false; error: string } {
+  const { entry, conventionIndex, blockIndex, sourceMap } = opts;
+  const ref = entry.use;
+  const location = `conventions[${conventionIndex}].must[${blockIndex}]`;
+
+  const lookup = lookupReusable({ ref, index: conventionIndex, sourceMap });
+  if (!lookup.success) {
+    return {
+      success: false,
+      error: lookup.error.replace(`conventions[${conventionIndex}]`, location),
+    };
+  }
+  const { reusable, prefix, name } = lookup;
+
+  const topLevelOnly: string[] = [];
+  if (reusable.paths !== undefined) {
+    topLevelOnly.push("paths");
+  }
+  if (reusable.severity !== undefined) {
+    topLevelOnly.push("severity");
+  }
+  if (topLevelOnly.length > 0) {
+    return {
+      success: false,
+      error: `Convention "${prefix}/${name}" referenced in ${location} declares top-level-only field(s) ${topLevelOnly
+        .map((f) => `"${f}"`)
+        .join(
+          ", "
+        )}. Such conventions can only be referenced at the top level of conventions[]. Either remove the field(s) from the source convention, or move the reference out of must[].`,
+    };
+  }
+
+  const { use: _use, ...overrides } = entry;
+
+  const base: Record<string, unknown> = {
+    must: reusable.must,
+  };
+  if (reusable.name !== undefined) {
+    base.name = reusable.name;
+  }
+  if (reusable.description !== undefined) {
+    base.description = reusable.description;
+  }
+  if (reusable.if !== undefined) {
+    base.if = reusable.if;
+  }
+  if (reusable.for !== undefined) {
+    base.for = reusable.for;
+  }
+  if (reusable.excludeFiles !== undefined) {
+    base.excludeFiles = reusable.excludeFiles;
+  }
+
+  const merged = deepMerge({ base, override: overrides });
+
+  const validated = MustBlockV1Schema.safeParse(merged);
+  if (!validated.success) {
+    const issues = validated.error.issues
+      .map(
+        (issue) =>
+          `  - ${location}${issue.path.length > 0 ? `.${issue.path.join(".")}` : ""}: ${issue.message}`
+      )
+      .join("\n");
+    return {
+      success: false,
+      error: `Expanded must-block reference "${prefix}/${name}" failed validation at ${location}:\n${issues}`,
+    };
+  }
+
+  return { success: true, block: validated.data };
 }
 
 function lookupReusable(opts: {

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -503,4 +503,116 @@ describe("ConfigV1Schema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("accepts a hand-written convention whose must[] contains a use ref", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [
+            { must: { haveType: "directory" } },
+            { use: "common/some-must-block" },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a use ref inside must[] with override fields (if/for/excludeFiles/must)", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [
+            {
+              use: "common/some-must-block",
+              if: { hasFile: "${name}.ts" },
+              for: { files: "${name}.ts" },
+              excludeFiles: ["${name}.skip.ts"],
+              must: { haveType: "file" },
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a use ref inside must[] overriding name and description", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [
+            {
+              use: "common/foo",
+              name: "renamed",
+              description: "Overridden description.",
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a use ref inside must[] with an unknown override field (strict)", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [{ use: "common/foo", unknownField: "x" }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a use ref inside must[] with paths or severity (top-level only)", () => {
+    const withPaths = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [{ use: "common/foo", paths: "src/*.ts" }],
+        },
+      ],
+    });
+    expect(withPaths.success).toBe(false);
+
+    const withSeverity = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventionSources: { common: "./x.json" },
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [{ use: "common/foo", severity: "warning" }],
+        },
+      ],
+    });
+    expect(withSeverity.success).toBe(false);
+  });
+
+  it("rejects a use ref inside must[] with a malformed use string", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/{name}",
+          must: [{ use: "not-a-reference" }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/konsistent/src/config/schema.ts
+++ b/packages/konsistent/src/config/schema.ts
@@ -39,6 +39,30 @@ export const ConventionV1Schema = z.strictObject({
   must: z.union([MustPredicatesV1Schema, z.array(MustBlockV1Schema)]),
 });
 
+export const MustBlockUseRefSchema = MustBlockV1Schema.partial().extend({
+  use: z
+    .string()
+    .regex(
+      /^[a-z0-9-]+\/[a-z0-9-]+$/,
+      'Must block "use" must match "<vendor>/<name>"'
+    ),
+});
+
+const RawHandWrittenConventionV1Schema = z.strictObject({
+  name: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, "Convention name must match [a-z0-9-]+")
+    .optional(),
+  description: z.string().optional(),
+  severity: z.enum(["error", "warning"]).default("error").optional(),
+  excludeFiles: z.array(z.string()).optional(),
+  paths: z.union([z.string(), z.array(z.string())]),
+  must: z.union([
+    MustPredicatesV1Schema,
+    z.array(z.union([MustBlockV1Schema, MustBlockUseRefSchema])),
+  ]),
+});
+
 const ConventionStringRefSchema = z
   .string()
   .regex(
@@ -83,11 +107,12 @@ export const ConfigV1Schema = z.strictObject({
     z.union([
       ConventionStringRefSchema,
       ConventionUseRefSchema,
-      ConventionV1Schema,
+      RawHandWrittenConventionV1Schema,
     ])
   ),
 });
 
+export type MustBlockUseRefV1 = z.infer<typeof MustBlockUseRefSchema>;
 export type RawConfigV1 = z.infer<typeof ConfigV1Schema>;
 export type ConventionV1 = z.infer<typeof ConventionV1Schema>;
 export type ConfigV1 = Omit<


### PR DESCRIPTION
So far, a `use` reference` to a reusable convention was only allowed at the top-level, but inner must blocks need to support it too.