### PR TITLE
fix file counting so that files in child `for` loops are also counted

### DIFF
--- a/packages/konsistent/package.json
+++ b/packages/konsistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "konsistent",
   "description": "konsistent is a CLI tool that enforces structural conventions in TypeScript codebases.",
-  "version": "0.0.1-alpha.19",
+  "version": "0.0.1-alpha.20",
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -394,8 +394,12 @@ describe("run", () => {
       directories: new Set(["components/Button"]),
       files: new Set(["components/Button/Button.test.tsx"]),
     });
-    const { diagnostics } = await run({ config, fileSystem: fs });
+    const { diagnostics, filesChecked } = await run({
+      config,
+      fileSystem: fs,
+    });
     expect(diagnostics).toEqual([]);
+    expect(filesChecked).toBe(2);
   });
 
   it("silently skips when for.files matches zero files", async () => {

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -426,6 +426,7 @@ async function evaluateForBlock(opts: {
   conventionName?: string;
   fileStructureCache: Map<string, FileStructure>;
   severity?: DiagnosticSeverity;
+  checkedPaths: Set<string>;
   kebabToPascalMap?: Record<string, string>;
   kebabToCamelMap?: Record<string, string>;
   pascalToKebabMap?: Record<string, string>;
@@ -440,6 +441,7 @@ async function evaluateForBlock(opts: {
     conventionName,
     fileStructureCache,
     severity,
+    checkedPaths,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -496,6 +498,7 @@ async function evaluateForBlock(opts: {
 
   const diagnostics: Diagnostic[] = [];
   for (const entry of matched) {
+    checkedPaths.add(entry.path);
     const mergedPlaceholders = { ...entry.placeholders };
     for (const [key, value] of Object.entries(parentContext.placeholders)) {
       mergedPlaceholders[key] = value;
@@ -632,6 +635,7 @@ export async function run(opts: {
             }),
             fileStructureCache,
             severity,
+            checkedPaths,
             kebabToPascalMap,
             kebabToCamelMap,
             pascalToKebabMap,


### PR DESCRIPTION
When running `konsistent`, it currently only reports the number of files inspected based on the top-level `conventions[i].paths` matched.

However, conventions can have arrays of multiple requirements, and some of those can include `for` matchers for other files. So far, those files inspected were ignored in the count, which was misleading.