### PR TITLE
chore: enforce minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,9 +27,6 @@ allowBuilds:
 minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
-  - '@turbo/*'
   - 'turbo'
-  - '@vercel/*'
-  - '@workflow/*'
   - 'konsistent'
   - '@konsistent/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,13 @@ catalog:
 
 allowBuilds:
   esbuild: true
+
+minimumReleaseAge: 2880 # 2 days
+
+minimumReleaseAgeExclude:
+  - '@turbo/*'
+  - 'turbo'
+  - '@vercel/*'
+  - '@workflow/*'
+  - 'konsistent'
+  - '@konsistent/*'


### PR DESCRIPTION
Enforces minimum package release age of 2 days, with relevant exclusions
