### PR TITLE
add `areBarrelFiles` predicate

### DIFF
--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -19,6 +19,8 @@ The full machine-readable schema lives at `node_modules/konsistent/konsistent.sc
 - [Import predicates](#import-predicates)
   - [`import`](#import)
   - [`importTypes`](#importtypes)
+- [Structural predicates](#structural-predicates)
+  - [`areBarrelFiles`](#arebarrelfiles)
 
 All predicates support template substitutions in their string values — see [path-patterns.md](./path-patterns.md#case-transformations) for the full case-transformation catalog.
 
@@ -244,6 +246,45 @@ Assert type-only imports (`import type { ... } from`).
 ```
 
 Same shape as `import`. Useful for enforcing dependency direction — every adapter's implementation file must `import type` its base from a specific module.
+
+---
+
+## Structural predicates
+
+### `areBarrelFiles`
+
+Assert that the matched files are pure barrel files: every top-level statement must be a re-export of another module, not a local declaration.
+
+```json
+{
+  "paths": "src/{moduleName}",
+  "must": [
+    {
+      "for": { "files": "index.ts" },
+      "must": { "areBarrelFiles": true }
+    }
+  ]
+}
+```
+
+A file passes when every top-level statement is one of:
+
+- An `import` declaration of any form, including bare side-effect imports (`import "./polyfill"`).
+- A re-export with a module specifier: `export * from "./x"`, `export * as ns from "./x"`, `export { a, b as c } from "./x"`, `export { default } from "./x"`, `export { default as Foo } from "./x"`.
+- `export { a, b as c }` where every specifier references an identifier brought in by an `import` statement in the same file. Aliasing (`as`) is allowed because it is a pure re-export.
+- `export default <Identifier>` where the identifier was brought in by an `import` statement in the same file.
+
+Every other top-level construct produces a diagnostic:
+
+| Violation kind | Example | Message |
+| --- | --- | --- |
+| `declaration` | `const x = 1;`, `function f() {}`, `class C {}`, `enum E {}`, `type T = ...`, `interface I {}` | `Barrel file must not contain declarations` |
+| `expression` | `doSomething();` | `Barrel file must not contain top-level expression statements` |
+| `default-expression` | `export default { a: 1 };`, `export default 42;` | `Barrel file default export must re-export an imported identifier` |
+| `named-export-local` | `const x = 1; export { x };` | `Barrel file must only re-export imported identifiers` |
+| `export-equals` | `export = x;` | <code>Barrel file must not use &#96;export =&#96;</code> |
+
+The predicate takes a bare boolean (`true` enables, `false`/omitted disables). It does not enforce a filename — pair it with a `for` block or a `paths` pattern that targets the files you consider barrels.
 
 ---
 

--- a/e2e/barrel-files.test.ts
+++ b/e2e/barrel-files.test.ts
@@ -1,0 +1,60 @@
+import { execFile as execFileCb } from "node:child_process";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCb);
+
+const cliBinary = resolve(
+  import.meta.dirname,
+  "../packages/konsistent/dist/index.js"
+);
+
+const fixturesDir = resolve(import.meta.dirname, "fixtures");
+
+function runCli(opts: {
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}) {
+  return execFile("node", [cliBinary, ...(opts.args ?? [])], {
+    cwd: opts.cwd,
+    env: { ...process.env, GITHUB_ACTIONS: "", ...opts.env },
+  });
+}
+
+describe("barrel-files fixture", () => {
+  const cwd = resolve(fixturesDir, "barrel-files");
+
+  it("konsistent check exits 0 when the index file only re-exports", async () => {
+    await expect(runCli({ args: ["check"], cwd })).resolves.not.toThrow();
+  });
+
+  it("konsistent validate accepts the areBarrelFiles predicate", async () => {
+    const { stdout } = await runCli({ args: ["validate"], cwd });
+    expect(stdout).toContain("Configuration is valid");
+  });
+});
+
+describe("barrel-files-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "barrel-files-broken");
+
+  it("konsistent check exits 1 when the index file declares a constant", async () => {
+    try {
+      await runCli({ args: ["check"], cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as {
+        stdout: string;
+        stderr: string;
+        code: number;
+        status: number;
+      };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain(
+        "Barrel file must not contain declarations"
+      );
+      expect(error.stdout).toContain("barrels-must-be-pure");
+    }
+  });
+});

--- a/e2e/fixtures/barrel-files-broken/konsistent.json
+++ b/e2e/fixtures/barrel-files-broken/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "barrels-must-be-pure",
+      "description": "Index files must be pure barrels.",
+      "paths": "src/{moduleName}",
+      "must": [
+        {
+          "for": { "files": "index.ts" },
+          "must": { "areBarrelFiles": true }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/barrel-files-broken/src/widgets/index.ts
+++ b/e2e/fixtures/barrel-files-broken/src/widgets/index.ts
@@ -1,0 +1,3 @@
+export * from "./widget.js";
+
+export const VERSION = "1.0.0";

--- a/e2e/fixtures/barrel-files-broken/src/widgets/widget.ts
+++ b/e2e/fixtures/barrel-files-broken/src/widgets/widget.ts
@@ -1,0 +1,3 @@
+export function makeWidget(name: string): { name: string } {
+  return { name };
+}

--- a/e2e/fixtures/barrel-files/konsistent.json
+++ b/e2e/fixtures/barrel-files/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "barrels-must-be-pure",
+      "description": "Index files must be pure barrels.",
+      "paths": "src/{moduleName}",
+      "must": [
+        {
+          "for": { "files": "index.ts" },
+          "must": { "areBarrelFiles": true }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/barrel-files/src/widgets/helpers.ts
+++ b/e2e/fixtures/barrel-files/src/widgets/helpers.ts
@@ -1,0 +1,3 @@
+export function describeWidget(name: string): string {
+  return `widget:${name}`;
+}

--- a/e2e/fixtures/barrel-files/src/widgets/index.ts
+++ b/e2e/fixtures/barrel-files/src/widgets/index.ts
@@ -1,0 +1,5 @@
+import { describeWidget } from "./helpers.js";
+
+export * from "./widget.js";
+export { describeWidget };
+export { describeWidget as renderWidget };

--- a/e2e/fixtures/barrel-files/src/widgets/widget.ts
+++ b/e2e/fixtures/barrel-files/src/widgets/widget.ts
@@ -1,0 +1,5 @@
+export function makeWidget(name: string): { name: string } {
+  return { name };
+}
+
+export const WIDGET_KIND = "widget";

--- a/packages/common-conventions/package.json
+++ b/packages/common-conventions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@konsistent/common-conventions",
   "description": "Common reusable conventions for konsistent. Authored in TypeScript via @konsistent/convention, shipped as a JSON artifact via the \"./konsistent\" exports condition.",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/convention/package.json
+++ b/packages/convention/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@konsistent/convention",
   "description": "Convention spec for konsistent — Zod schemas and authoring helpers for reusable conventions.",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -58,6 +58,7 @@ export const MustPredicatesV1Schema = z.strictObject({
   importTypes: z
     .array(z.union([z.string(), ImportDefinitionV1Schema]))
     .optional(),
+  areBarrelFiles: z.boolean().optional(),
 });
 
 export const MustBlockV1Schema = z.strictObject({

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -386,6 +386,9 @@
                         }
                       ]
                     }
+                  },
+                  "areBarrelFiles": {
+                    "type": "boolean"
                   }
                 },
                 "additionalProperties": false
@@ -697,6 +700,9 @@
                             }
                           ]
                         }
+                      },
+                      "areBarrelFiles": {
+                        "type": "boolean"
                       }
                     },
                     "additionalProperties": false
@@ -1025,6 +1031,9 @@
                                       }
                                     ]
                                   }
+                                },
+                                "areBarrelFiles": {
+                                  "type": "boolean"
                                 }
                               },
                               "additionalProperties": false
@@ -1349,6 +1358,9 @@
                                       }
                                     ]
                                   }
+                                },
+                                "areBarrelFiles": {
+                                  "type": "boolean"
                                 }
                               },
                               "additionalProperties": false

--- a/packages/konsistent/package.json
+++ b/packages/konsistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "konsistent",
   "description": "konsistent is a CLI tool that enforces structural conventions in TypeScript codebases.",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -7,6 +7,7 @@ import type {
 import { checkHaveFiles } from "../predicates/have-files.js";
 import { checkHaveType } from "../predicates/have-type.js";
 import { parseFileStructure } from "../typescript/parser.js";
+import { checkAreBarrelFiles } from "../typescript/predicates/are-barrel-files.js";
 import { checkExport } from "../typescript/predicates/export.js";
 import { checkExportClasses } from "../typescript/predicates/export-classes.js";
 import { checkExportConstants } from "../typescript/predicates/export-constants.js";
@@ -63,6 +64,7 @@ export const TS_PREDICATES = new Set([
   "exportInterfaces",
   "import",
   "importTypes",
+  "areBarrelFiles",
 ]);
 
 function invertMap(
@@ -311,6 +313,22 @@ const TS_PREDICATE_HANDLERS: Record<
     must.importTypes
       ? checkImportTypes({
           expected: must.importTypes,
+          context,
+          fileStructure,
+          conventionName,
+          severity,
+        })
+      : [],
+  areBarrelFiles: ({
+    must,
+    context,
+    fileStructure,
+    conventionName,
+    severity,
+  }) =>
+    must.areBarrelFiles
+      ? checkAreBarrelFiles({
+          expected: must.areBarrelFiles,
           context,
           fileStructure,
           conventionName,

--- a/packages/konsistent/src/typescript/parser.test.ts
+++ b/packages/konsistent/src/typescript/parser.test.ts
@@ -568,4 +568,100 @@ describe("parseFileStructure", () => {
       expect(result.exports.length).toBeGreaterThanOrEqual(6);
     });
   });
+
+  describe("nonBarrelStatements", () => {
+    it("is empty for a barrel using export-from in all forms", () => {
+      const result = parseFileStructure({
+        source: [
+          "export * from './a';",
+          "export * as ns from './b';",
+          "export { a, b as c } from './c';",
+          "export { default } from './d';",
+          "export { default as Foo } from './e';",
+          "import './polyfill';",
+        ].join("\n"),
+      });
+      expect(result.nonBarrelStatements).toEqual([]);
+    });
+
+    it("is empty when named export references an imported identifier", () => {
+      const result = parseFileStructure({
+        source: "import { x } from './x';\nexport { x };",
+      });
+      expect(result.nonBarrelStatements).toEqual([]);
+    });
+
+    it("is empty when named export aliases an imported identifier", () => {
+      const result = parseFileStructure({
+        source: "import { x } from './x';\nexport { x as y };",
+      });
+      expect(result.nonBarrelStatements).toEqual([]);
+    });
+
+    it("is empty when default export forwards an imported identifier", () => {
+      const result = parseFileStructure({
+        source: "import x from './x';\nexport default x;",
+      });
+      expect(result.nonBarrelStatements).toEqual([]);
+    });
+
+    it("flags default export of a non-identifier expression", () => {
+      const result = parseFileStructure({
+        source: "export default { a: 1 };",
+      });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("default-expression");
+    });
+
+    it("flags default export of a literal", () => {
+      const result = parseFileStructure({ source: "export default 42;" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("default-expression");
+    });
+
+    it("flags named export of a locally declared identifier", () => {
+      const result = parseFileStructure({
+        source: "const x = 1;\nexport { x };",
+      });
+      const kinds = result.nonBarrelStatements.map((n) => n.kind);
+      expect(kinds).toContain("declaration");
+      expect(kinds).toContain("named-export-local");
+    });
+
+    it("flags local const declarations", () => {
+      const result = parseFileStructure({ source: "const x = 1;" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("declaration");
+    });
+
+    it("flags exported const declarations", () => {
+      const result = parseFileStructure({ source: "export const x = 1;" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("declaration");
+    });
+
+    it("flags enum declarations", () => {
+      const result = parseFileStructure({ source: "enum E { A }" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("declaration");
+    });
+
+    it("flags exported enum declarations", () => {
+      const result = parseFileStructure({ source: "export enum E { A }" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("declaration");
+    });
+
+    it("flags top-level expression statements", () => {
+      const result = parseFileStructure({ source: "doSomething();" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("expression");
+    });
+
+    it("flags export equals", () => {
+      const result = parseFileStructure({ source: "export = x;" });
+      expect(result.nonBarrelStatements).toHaveLength(1);
+      expect(result.nonBarrelStatements[0].kind).toBe("export-equals");
+    });
+  });
 });

--- a/packages/konsistent/src/typescript/parser.ts
+++ b/packages/konsistent/src/typescript/parser.ts
@@ -8,6 +8,7 @@ import type {
   FunctionInfo,
   ImportInfo,
   InterfaceInfo,
+  NonBarrelStatementInfo,
   ParamInfo,
   SourcePosition,
   TypeAliasInfo,
@@ -192,6 +193,7 @@ interface ParseCollector {
   functions: FunctionInfo[];
   imports: ImportInfo[];
   interfaces: InterfaceInfo[];
+  nonBarrelStatements: NonBarrelStatementInfo[];
   typeAliases: TypeAliasInfo[];
 }
 
@@ -358,6 +360,7 @@ export function parseFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 
@@ -390,5 +393,102 @@ export function parseFileStructure(opts: {
     }
   });
 
+  classifyNonBarrelStatements({ sourceFile, collector });
+
   return collector;
+}
+
+function classifyNonBarrelStatements(opts: {
+  sourceFile: ts.SourceFile;
+  collector: ParseCollector;
+}): void {
+  const { sourceFile, collector } = opts;
+  const importedNames = new Set(collector.imports.map((i) => i.name));
+
+  ts.forEachChild(sourceFile, (node) => {
+    const kind = classifyTopLevelNode({ node, sourceFile, importedNames });
+    if (kind) {
+      collector.nonBarrelStatements.push({
+        kind,
+        pos: getPosition({ sourceFile, node }),
+      });
+    }
+  });
+}
+
+function classifyExportDeclaration(opts: {
+  node: ts.ExportDeclaration;
+  sourceFile: ts.SourceFile;
+  importedNames: Set<string>;
+}): NonBarrelStatementInfo["kind"] | undefined {
+  const { node, sourceFile, importedNames } = opts;
+  if (node.moduleSpecifier) {
+    return;
+  }
+  if (!(node.exportClause && ts.isNamedExports(node.exportClause))) {
+    return;
+  }
+  for (const element of node.exportClause.elements) {
+    const sourceName = (element.propertyName ?? element.name).getText(
+      sourceFile
+    );
+    if (!importedNames.has(sourceName)) {
+      return "named-export-local";
+    }
+  }
+  return;
+}
+
+function classifyExportAssignment(opts: {
+  node: ts.ExportAssignment;
+  sourceFile: ts.SourceFile;
+  importedNames: Set<string>;
+}): NonBarrelStatementInfo["kind"] | undefined {
+  const { node, sourceFile, importedNames } = opts;
+  if (node.isExportEquals) {
+    return "export-equals";
+  }
+  if (
+    ts.isIdentifier(node.expression) &&
+    importedNames.has(node.expression.getText(sourceFile))
+  ) {
+    return;
+  }
+  return "default-expression";
+}
+
+function isDeclarationNode(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isInterfaceDeclaration(node) ||
+    ts.isTypeAliasDeclaration(node) ||
+    ts.isEnumDeclaration(node) ||
+    ts.isVariableStatement(node) ||
+    ts.isModuleDeclaration(node)
+  );
+}
+
+function classifyTopLevelNode(opts: {
+  node: ts.Node;
+  sourceFile: ts.SourceFile;
+  importedNames: Set<string>;
+}): NonBarrelStatementInfo["kind"] | undefined {
+  const { node, sourceFile, importedNames } = opts;
+  if (ts.isImportDeclaration(node)) {
+    return;
+  }
+  if (ts.isExportDeclaration(node)) {
+    return classifyExportDeclaration({ node, sourceFile, importedNames });
+  }
+  if (ts.isExportAssignment(node)) {
+    return classifyExportAssignment({ node, sourceFile, importedNames });
+  }
+  if (ts.isExpressionStatement(node)) {
+    return "expression";
+  }
+  if (isDeclarationNode(node)) {
+    return "declaration";
+  }
+  return;
 }

--- a/packages/konsistent/src/typescript/predicates/are-barrel-files.test.ts
+++ b/packages/konsistent/src/typescript/predicates/are-barrel-files.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { PredicateContext } from "../../core/context.js";
+import type { FileStructure } from "../types.js";
+import { checkAreBarrelFiles } from "./are-barrel-files.js";
+
+function createMockContext(opts: { path: string }): PredicateContext {
+  return {
+    path: opts.path,
+    placeholders: {} as PredicateContext["placeholders"],
+    resolveTemplate: (t: string) => t,
+    fileExists: () => false,
+    readDir: () => [],
+  };
+}
+
+function createMockFileStructure(opts: {
+  nonBarrelStatements?: FileStructure["nonBarrelStatements"];
+}): FileStructure {
+  return {
+    exports: [],
+    imports: [],
+    interfaces: [],
+    classes: [],
+    functions: [],
+    constants: [],
+    nonBarrelStatements: opts.nonBarrelStatements ?? [],
+    typeAliases: [],
+  };
+}
+
+describe("checkAreBarrelFiles", () => {
+  it("returns no diagnostics when expected is false", () => {
+    const result = checkAreBarrelFiles({
+      expected: false,
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: createMockFileStructure({
+        nonBarrelStatements: [
+          { kind: "declaration", pos: { line: 1, column: 1 } },
+        ],
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns no diagnostics when file has no non-barrel statements", () => {
+    const result = checkAreBarrelFiles({
+      expected: true,
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: createMockFileStructure({ nonBarrelStatements: [] }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("emits one diagnostic per non-barrel statement", () => {
+    const result = checkAreBarrelFiles({
+      expected: true,
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: createMockFileStructure({
+        nonBarrelStatements: [
+          { kind: "declaration", pos: { line: 3, column: 1 } },
+          { kind: "expression", pos: { line: 7, column: 1 } },
+        ],
+      }),
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].predicateName).toBe("areBarrelFiles");
+    expect(result[0].filePath).toBe("src/index.ts");
+    expect(result[0].line).toBe(3);
+    expect(result[0].column).toBe(1);
+    expect(result[0].message).toBe("Barrel file must not contain declarations");
+    expect(result[1].line).toBe(7);
+    expect(result[1].message).toBe(
+      "Barrel file must not contain top-level expression statements"
+    );
+  });
+
+  it("uses kind-specific messages for default-expression, named-export-local, and export-equals", () => {
+    const result = checkAreBarrelFiles({
+      expected: true,
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: createMockFileStructure({
+        nonBarrelStatements: [
+          { kind: "default-expression", pos: { line: 1, column: 1 } },
+          { kind: "named-export-local", pos: { line: 2, column: 1 } },
+          { kind: "export-equals", pos: { line: 3, column: 1 } },
+        ],
+      }),
+    });
+    expect(result.map((d) => d.message)).toEqual([
+      "Barrel file default export must re-export an imported identifier",
+      "Barrel file must only re-export imported identifiers",
+      "Barrel file must not use `export =`",
+    ]);
+  });
+
+  it("includes conventionName when provided", () => {
+    const result = checkAreBarrelFiles({
+      expected: true,
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: createMockFileStructure({
+        nonBarrelStatements: [
+          { kind: "declaration", pos: { line: 1, column: 1 } },
+        ],
+      }),
+      conventionName: "barrel-only",
+    });
+    expect(result[0].conventionName).toBe("barrel-only");
+  });
+});

--- a/packages/konsistent/src/typescript/predicates/are-barrel-files.ts
+++ b/packages/konsistent/src/typescript/predicates/are-barrel-files.ts
@@ -1,0 +1,38 @@
+import type { PredicateContext } from "../../core/context.js";
+import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
+import { createDiagnostic } from "../../core/diagnostics.js";
+import type { FileStructure, NonBarrelStatementInfo } from "../types.js";
+
+const MESSAGES: Record<NonBarrelStatementInfo["kind"], string> = {
+  declaration: "Barrel file must not contain declarations",
+  expression: "Barrel file must not contain top-level expression statements",
+  "default-expression":
+    "Barrel file default export must re-export an imported identifier",
+  "named-export-local": "Barrel file must only re-export imported identifiers",
+  "export-equals": "Barrel file must not use `export =`",
+};
+
+export function checkAreBarrelFiles(opts: {
+  expected: boolean;
+  context: PredicateContext;
+  fileStructure: FileStructure;
+  conventionName?: string;
+  severity?: DiagnosticSeverity;
+}): Diagnostic[] {
+  const { expected, context, fileStructure, conventionName, severity } = opts;
+  if (!expected) {
+    return [];
+  }
+
+  return fileStructure.nonBarrelStatements.map((entry) =>
+    createDiagnostic({
+      filePath: context.path,
+      predicateName: "areBarrelFiles",
+      message: MESSAGES[entry.kind],
+      conventionName,
+      line: entry.pos.line,
+      column: entry.pos.column,
+      severity,
+    })
+  );
+}

--- a/packages/konsistent/src/typescript/predicates/export-classes.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-classes.test.ts
@@ -36,6 +36,7 @@ function createMockFileStructure(opts: {
     })),
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/export-constants.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-constants.test.ts
@@ -32,6 +32,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/export-functions.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-functions.test.ts
@@ -33,6 +33,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: opts.functions ?? [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/export-interfaces.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-interfaces.test.ts
@@ -33,6 +33,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/export-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.test.ts
@@ -32,6 +32,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/export.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export.test.ts
@@ -32,6 +32,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/import-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import-types.test.ts
@@ -32,6 +32,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/predicates/import.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import.test.ts
@@ -32,6 +32,7 @@ function createMockFileStructure(opts: {
     classes: [],
     functions: [],
     constants: [],
+    nonBarrelStatements: [],
     typeAliases: [],
   };
 }

--- a/packages/konsistent/src/typescript/types.ts
+++ b/packages/konsistent/src/typescript/types.ts
@@ -64,6 +64,18 @@ export interface TypeAliasInfo {
   pos: SourcePosition;
 }
 
+export type NonBarrelStatementKind =
+  | "declaration"
+  | "expression"
+  | "default-expression"
+  | "named-export-local"
+  | "export-equals";
+
+export interface NonBarrelStatementInfo {
+  kind: NonBarrelStatementKind;
+  pos: SourcePosition;
+}
+
 export interface FileStructure {
   classes: ClassInfo[];
   constants: ConstantInfo[];
@@ -71,5 +83,6 @@ export interface FileStructure {
   functions: FunctionInfo[];
   imports: ImportInfo[];
   interfaces: InterfaceInfo[];
+  nonBarrelStatements: NonBarrelStatementInfo[];
   typeAliases: TypeAliasInfo[];
 }


### PR DESCRIPTION
Adds a new `areBarrelFiles` predicate that asserts the matched files are pure barrel files — i.e., their only top-level statements are re-exports of sibling modules.
