### PR TITLE
fix package publishing for PNPM 11

### DIFF
--- a/packages/konsistent/package.json
+++ b/packages/konsistent/package.json
@@ -24,7 +24,7 @@
     "generate-schema": "tsx scripts/generate-schema.ts",
     "test": "vitest run",
     "prepack": "cp -r ../../docs ./docs",
-    "postpack": "del-cli docs"
+    "post-publish-clean": "del-cli docs"
   },
   "dependencies": {
     "@konsistent/convention": "workspace:*",

--- a/tools/scripts/publish-packages.mjs
+++ b/tools/scripts/publish-packages.mjs
@@ -88,7 +88,33 @@ async function readPackage({ folderName }) {
     version: packageJson.version,
     dependencies: packageJson.dependencies ?? {},
     optionalDependencies: packageJson.optionalDependencies ?? {},
+    scripts: packageJson.scripts ?? {},
   };
+}
+
+const POST_PUBLISH_CLEAN_SCRIPT = "post-publish-clean";
+
+async function runPostPublishClean({ packages }) {
+  for (const pkg of packages) {
+    if (!pkg.scripts[POST_PUBLISH_CLEAN_SCRIPT]) {
+      continue;
+    }
+
+    console.log(`Running ${POST_PUBLISH_CLEAN_SCRIPT} for ${pkg.name}`);
+
+    const result = await runCommand({
+      command: "pnpm",
+      args: ["run", POST_PUBLISH_CLEAN_SCRIPT],
+      cwd: pkg.packageDir,
+      allowFailure: true,
+    });
+
+    if (result.status !== 0) {
+      console.error(
+        `${POST_PUBLISH_CLEAN_SCRIPT} for ${pkg.name} failed:\n${result.stderr || result.stdout}`
+      );
+    }
+  }
 }
 
 async function readPackages() {
@@ -330,10 +356,16 @@ async function main() {
     return;
   }
 
-  await publishPackages({
-    packages: packagesToPublish,
-    dryRun,
-  });
+  try {
+    await publishPackages({
+      packages: packagesToPublish,
+      dryRun,
+    });
+  } finally {
+    await runPostPublishClean({
+      packages: packagesToPublish,
+    });
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
PNPM 11 has a regression due to its now native package publishing implementation. Wiping the files in `postpack` now means they'll be gone too early, before the package has been actually published.