### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,18 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    # do not attempt running in forks
     if: github.repository_owner == 'vercel-labs'
     steps:
       - name: Configure Git
@@ -50,17 +53,20 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      # Double install: @konsistent/common-conventions's build script invokes the
+      # `konsistent-convention` CLI shipped by @konsistent/convention. The bin
+      # symlink can only be created once @konsistent/convention/dist/cli.js
+      # exists, so we install, build the producer, wipe node_modules, then
+      # reinstall to link the bin. pnpm 11's warm-reinstall skips re-linking
+      # if node_modules looks current (--force isn't enough), so the wipe is
+      # required. Outside this monorepo, npm/pnpm consumers install the
+      # already-built tarball and never hit this.
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-
-      # The @konsistent/common-conventions build script invokes the konsistent-convention
-      # CLI shipped by @konsistent/convention, whose bin symlink only materializes after a
-      # build. See .github/workflows/ci.yml for the same workaround.
-      - name: Pre-build convention package
-        run: pnpm -F @konsistent/convention build
-
-      - name: Re-install to link convention bin
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm -F @konsistent/convention build
+          rm -rf node_modules packages/*/node_modules e2e/fixtures/*/node_modules
+          pnpm install --frozen-lockfile
 
       # Normal release path
       - name: Create Release Pull Request or Publish to npm

--- a/tools/scripts/verify-changesets.mjs
+++ b/tools/scripts/verify-changesets.mjs
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..", "..");
-const ALLOWED_BUMPS = new Set(["patch"]);
 const NEWLINE_RE = /\r?\n/;
 const FRONTMATTER_RE = /^---\n([\s\S]+?)\n---/;
 const QUOTE_RE = /^['"]|['"]$/g;
@@ -23,8 +22,54 @@ async function writeSummary(body) {
   await fs.appendFile(file, `${body}\n`);
 }
 
-async function parseChangeset(relativePath) {
-  const absolutePath = path.join(ROOT, relativePath);
+async function getPackageVersions({ root }) {
+  const packagesPath = path.join(root, "packages");
+  let packageDirs;
+  try {
+    packageDirs = await fs.readdir(packagesPath, { withFileTypes: true });
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return new Map();
+    }
+    throw error;
+  }
+  const versions = new Map();
+  for (const packageDir of packageDirs) {
+    if (!packageDir.isDirectory()) {
+      continue;
+    }
+    const packageJsonPath = path.join(
+      packagesPath,
+      packageDir.name,
+      "package.json"
+    );
+    let packageJson;
+    try {
+      packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
+    } catch (error) {
+      if (error && typeof error === "object" && error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    if (
+      packageJson &&
+      typeof packageJson.name === "string" &&
+      typeof packageJson.version === "string"
+    ) {
+      versions.set(packageJson.name, packageJson.version);
+    }
+  }
+  return versions;
+}
+
+function isInvalidBump({ bump, packageVersions, pkg }) {
+  const expected = packageVersions.get(pkg) === "0.0.0" ? "major" : "patch";
+  return bump !== expected;
+}
+
+async function parseChangeset({ relativePath, root }) {
+  const absolutePath = path.join(root, relativePath);
   const stat = await fs.lstat(absolutePath);
   if (stat.isSymbolicLink()) {
     throw new Error(
@@ -65,11 +110,13 @@ async function parseChangeset(relativePath) {
   return bumps;
 }
 
-async function main() {
-  const packageFiles = splitLines(process.env.PACKAGE_FILES);
-  const addedChangesets = splitLines(process.env.ADDED_CHANGESETS);
-  const allChangedChangesets = splitLines(process.env.ALL_CHANGED_CHANGESETS);
-
+async function verifyChangesets({
+  addedChangesets,
+  allChangedChangesets,
+  packageFiles,
+  root,
+}) {
+  const packageVersions = await getPackageVersions({ root });
   const errors = [];
 
   if (packageFiles.length > 0 && addedChangesets.length === 0) {
@@ -91,9 +138,9 @@ async function main() {
       continue;
     }
     try {
-      const bumps = await parseChangeset(file);
-      const invalid = Object.entries(bumps).filter(
-        ([, bump]) => !ALLOWED_BUMPS.has(bump)
+      const bumps = await parseChangeset({ relativePath: file, root });
+      const invalid = Object.entries(bumps).filter(([pkg, bump]) =>
+        isInvalidBump({ bump, packageVersions, pkg })
       );
       if (invalid.length > 0) {
         errors.push(
@@ -109,6 +156,20 @@ async function main() {
       errors.push(error.message);
     }
   }
+
+  return errors;
+}
+
+async function main() {
+  const packageFiles = splitLines(process.env.PACKAGE_FILES);
+  const addedChangesets = splitLines(process.env.ADDED_CHANGESETS);
+  const allChangedChangesets = splitLines(process.env.ALL_CHANGED_CHANGESETS);
+  const errors = await verifyChangesets({
+    addedChangesets,
+    allChangedChangesets,
+    packageFiles,
+    root: ROOT,
+  });
 
   if (errors.length > 0) {
     await writeSummary(


### PR DESCRIPTION
## Pull Request Description

See https://github.com/vercel-labs/konsistent/actions/runs/28108086504/job/83227713715: The `release.yml` workflow was failing because it was missing the `node_modules` removal that's necessary with `pnpm` 11, per the workaround that's already in `ci.yml`.

The other problem is https://github.com/vercel-labs/konsistent/actions/runs/28108155991/job/83227961536?pr=32: For a new package (i.e. version is set to `0.0.0`), we have to require a `major` changeset - only otherwise `patch` is required.

## Relevant technical choices

- align dependency installation in `release.yml` with how it works in `ci.yml`
- harden permissions, only give the job the necessary permissions while keeping workflow permissions minimal
- require `major` changeset for packages with version 0.0.0, else require `patch`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)