### PR TITLE
fix CI build warnings

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,18 +53,18 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Double install: @konsistent/common-conventions's build script invokes the
-      # `konsistent-convention` CLI shipped by @konsistent/convention. The bin
-      # symlink can only be created once @konsistent/convention/dist/cli.js
-      # exists, so we install, build the producer, wipe node_modules, then
-      # reinstall to link the bin. pnpm 11's warm-reinstall skips re-linking
-      # if node_modules looks current (--force isn't enough), so the wipe is
-      # required. Outside this monorepo, npm/pnpm consumers install the
-      # already-built tarball and never hit this.
+      # Double install: workspace packages expose CLI bins from dist. The bin
+      # symlinks can only be created once those dist entrypoints exist, so we
+      # install, build the bin producers, wipe node_modules, then reinstall to
+      # link the bins. pnpm 11's warm-reinstall skips re-linking if node_modules
+      # looks current (--force isn't enough), so the wipe is required. Outside
+      # this monorepo, npm/pnpm consumers install already-built tarballs and
+      # never hit this.
       - name: Install Dependencies
         run: |
           pnpm install --frozen-lockfile
           pnpm -F @konsistent/convention build
+          pnpm -F konsistent build
           rm -rf node_modules packages/*/node_modules e2e/fixtures/*/node_modules
           pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fix:deps": "syncpack fix-mismatches && syncpack format",
     "publish:packages": "pnpm build && node tools/scripts/publish-packages.mjs",
     "changeset": "changeset",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
+    "ci:version": "pnpm -F @konsistent/convention build && pnpm -F konsistent build && changeset version && pnpm install --no-frozen-lockfile",
     "ci:release": "turbo build --filter='./packages/*' && changeset publish",
     "prepare": "husky",
     "konsistent": "KONSISTENT_NO_UPDATE_CHECK=true konsistent"


### PR DESCRIPTION
## Pull Request Description

Fixes the CI warnings seen e.g. here: https://github.com/vercel-labs/konsistent/actions/runs/28114584051/job/83250587161

Also ensures that private packages are ignored by `changeset` - they were falsely included in #39.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)