### PR TITLE
feat(skills): enhance `konsistent-config` skill to cover installation of the package

### DIFF
--- a/skills/konsistent-config/SKILL.md
+++ b/skills/konsistent-config/SKILL.md
@@ -15,6 +15,21 @@ description: >
 
 Create or modify a `konsistent.json` file that enforces structural conventions for the project. The `konsistent` CLI checks filesystem structure and TypeScript exports/imports — it is not a style linter.
 
+## Prerequisites
+
+Check if the `konsistent` package is already installed:
+
+- `konsistent` available in root `package.json`
+- `node_modules/konsistent` directory exists
+
+If not, the `konsistent` CLI must be installed first. Use the project's package manager. For example, with PNPM:
+
+```bash
+pnpm add konsistent --save-dev
+```
+
+Once the package has been successfully installed, proceed to the primary workflow.
+
 ## Workflow
 
 1. Check if `konsistent.json` already exists at the project root.

--- a/skills/konsistent-config/SKILL.md
+++ b/skills/konsistent-config/SKILL.md
@@ -21,11 +21,20 @@ Check if the `konsistent` package is already installed:
 
 - `konsistent` available in root `package.json`
 - `node_modules/konsistent` directory exists
+- a `konsistent` script exists in `package.json`
 
 If not, the `konsistent` CLI must be installed first. Use the project's package manager. For example, with PNPM:
 
 ```bash
 pnpm add konsistent --save-dev
+```
+
+Then, ensure `package.json` has a `konsistent` script which invokes the `konsistent` CLI. At a minimum:
+
+```
+  "scripts": {
+    "konsistent": "konsistent"
+  }
 ```
 
 Once the package has been successfully installed, proceed to the primary workflow.
@@ -73,8 +82,7 @@ If `node_modules/konsistent/docs/` is not present (e.g. the project doesn't have
 - Group related predicates in one convention when they apply to the same path.
 - Use separate conventions for the same path when different severities are needed.
 - Use path negation to exclude known exceptions rather than listing all included paths.
-- Check `package.json` for a `konsistent` script (e.g. `"konsistent": "konsistent"`) — if present, use `npm run konsistent` (or the project's package manager equivalent) instead of `npx konsistent`.
-- Validate the generated config by running `konsistent validate`.
-- Test the config against the actual codebase by running `konsistent` (with no arguments).
+- Validate the generated config by running `konsistent validate` via the `package.json` script (e.g. `pnpm konsistent validate`).
+- Test the config against the actual codebase by running `konsistent` via the `package.json` script (with no arguments).
 
 **Important reminder:** The objective is NOT to write a `konsistent.json` file that leads to zero errors when running the CLI. That would defeat the purpose. The objective is to create a konsistent.json file that identifies violations to patterns used in the codebase, even if they are not being 100% adhered to.


### PR DESCRIPTION
## Pull Request Description

So far, if a project that didn't already have the `konsistent` package installed used the `konsistent-config` skill, it would confuse the agent because it wouldn't know what `konsistent` is, and running `pnpm konsistent` wouldn't work.

This PR fixes that.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)