### PR TITLE
feat(skills): call out file relationships in `konsistent-config` skill

### DIFF
--- a/skills/konsistent-config/SKILL.md
+++ b/skills/konsistent-config/SKILL.md
@@ -82,6 +82,7 @@ If `node_modules/konsistent/docs/` is not present (e.g. the project doesn't have
 - Group related predicates in one convention when they apply to the same path.
 - Use separate conventions for the same path when different severities are needed.
 - Use path negation to exclude known exceptions rather than listing all included paths.
+- Consider conventions between related files as well, not only within a single file. Use the `haveFiles` predicate to ensure a specific other file exists based on the matched file, and use `for.files` to enforce conventions within specific other related files based on the matched file.
 - Validate the generated config by running `konsistent validate` via the `package.json` script (e.g. `pnpm konsistent validate`).
 - Test the config against the actual codebase by running `konsistent` via the `package.json` script (with no arguments).
 


### PR DESCRIPTION
## Pull Request Description

Using the `konsistent-config` skill doesn't mention anything about relationships between different files, and this is not obvious enough for agents to detect just from reading the predicates docs.

Establishing conventions for certain files based on other files is extremely powerful, so the skill should point the agent's attention to that capability.

## Checklist

<!--
Leave items unchecked that don't apply.
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)