### PR TITLE
feat(konsistent): add new `importFrom` predicate to check for imports from a specific location

### DIFF
--- a/.changeset/sunny-lights-obey.md
+++ b/.changeset/sunny-lights-obey.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): add new `importFrom` predicate to check for imports from a specific location

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 - [CLI](./reference/cli.md) — commands, flags, output formats, exit codes.
 - [konsistent.json configuration](./reference/configuration.md) — top-level schema and convention shape.
 - [Path patterns](./reference/path-patterns.md) — globs, placeholders, case transformations, negation.
-- [Predicates](./reference/predicates.md) — every `must` predicate (`haveType`, `haveFiles`, `export`, `exportTypes`, `exportConstants`, `exportFunctions`, `exportInterfaces`, `exportClasses`, `import`, `importTypes`, import source predicates).
+- [Predicates](./reference/predicates.md) — every `must` predicate (`haveType`, `haveFiles`, `export`, `exportTypes`, `exportConstants`, `exportFunctions`, `exportInterfaces`, `exportClasses`, `import`, `importFrom`, `importTypes`, import source predicates).
 - [Constraints](./reference/constraints.md) — `matches`, `segments` for filtering placeholders.
 - [Conditional rules](./reference/conditional-rules.md) — `if`, `for`, `excludeFiles` blocks inside `must` arrays.
 - [Case maps](./reference/case-maps.md) — `kebabToPascalMap`, `kebabToCamelMap` for acronyms and special casing.

--- a/docs/guides/exploring-codebases.md
+++ b/docs/guides/exploring-codebases.md
@@ -148,7 +148,7 @@ For every pattern you identify:
 - Required files → `haveFiles`.
 - Local declarations → `declareTypes`, `declareConstants`, `declareFunctions`, `declareInterfaces`, `declareClasses`.
 - Exports → `export`, `exportTypes`, `exportConstants`, `exportFunctions`, `exportInterfaces`, `exportClasses`.
-- Imports → `import`, `importTypes`, `importFromCurrentDir`, `importFromParents`, `importFromExternals`, `importTypesFromCurrentDir`, `importTypesFromParents`, `importTypesFromExternals`.
+- Imports → `import`, `importFrom`, `importTypes`, `importFromCurrentDir`, `importFromParents`, `importFromExternals`, `importTypesFromCurrentDir`, `importTypesFromParents`, `importTypesFromExternals`.
 - Optional file conditions → `if.hasFile` blocks.
 - Subset-only rules → `if.placeholderSatisfies` with a `matches` or `segments` constraint.
 

--- a/docs/guides/fixing-violations.md
+++ b/docs/guides/fixing-violations.md
@@ -210,17 +210,19 @@ Search first: grep for `X` and case/suffix variants. Also look for object factor
   - Adding `extends`/`implements` requires adding new methods or refactoring existing ones to match the contract.
   - Base class or interface does not exist after search.
 
-#### `import` / `importTypes`
+#### `import` / `importTypes` / `importFrom`
 
-Message: `Missing import "X" from "<module>"` or `Missing import type "X" from "<module>"`.
+Message: `Missing import "X" from "<module>"`, `Missing import type "X" from "<module>"`, or `Missing import from "<module>"`.
 
-Search first: confirm the export `X` exists at `<module>`. If not, find where `X` (or its variants) is currently imported from.
+Search first: confirm the export `X` exists at `<module>` for named-import rules, or that the target module/package is already used by sibling files for `importFrom`. If not, find where `X` (or its variants) is currently imported from.
 
 - **Trivial**:
   - Export exists at the specified module path → add the import statement.
   - Symbol is currently imported from a different path → change the import path.
+  - For `importFrom`, a sibling file imports from the same package/path for the same role → add the analogous import.
 - **Non-trivial**:
   - Export does not exist at the target path *and* the symbol does not exist anywhere. Usually cascades from a separate violation — fix that first; this one may resolve automatically.
+  - For `importFrom`, no sibling establishes why the dependency should exist. Adding a new dependency may be a design decision.
 
 If a single source file is missing an export and many consumers fail `import` rules pointing at it, fix the source once; consumers will then validate. Address the root cause, not the downstream symptoms.
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -24,6 +24,7 @@ The full machine-readable schema lives at `node_modules/konsistent/konsistent.sc
   - [`exportClasses`](#exportclasses)
 - [Import predicates](#import-predicates)
   - [`import`](#import)
+  - [`importFrom`](#importfrom)
   - [`importTypes`](#importtypes)
   - [`importFromCurrentDir`](#importfromcurrentdir)
   - [`importFromParents`](#importfromparents)
@@ -324,6 +325,24 @@ Assert named value imports.
 | `from` | string | Optional. Module specifier the import must come from. |
 
 Bare-string form (`"import": ["useState"]`) checks the binding regardless of source.
+
+### `importFrom`
+
+Assert that the file has at least one import statement from a specific module path or package.
+
+```json
+"must": { "importFrom": "react" }
+```
+
+```json
+"must": { "importFrom": "./setup" }
+```
+
+The value is a string. Relative and absolute path-like specifiers are matched exactly, so `"./setup"` only matches `import "./setup"`.
+
+Package roots match the package itself and its subpaths. For example, `"react"` matches imports from `"react"` and `"react/jsx-runtime"`, and `"@scope/pkg"` matches `"@scope/pkg"` and `"@scope/pkg/subpath"`. Similarly named packages such as `"react-dom"` or `"@scope/pkg-extra"` do not match.
+
+Both value imports and type-only imports count because this predicate checks import statements by source. Side-effect imports such as `import "./setup"` also count.
 
 ### `importTypes`
 

--- a/e2e/fixtures/import-from-broken/konsistent.json
+++ b/e2e/fixtures/import-from-broken/konsistent.json
@@ -1,0 +1,20 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "path-imports",
+      "paths": "src/path.ts",
+      "must": { "importFrom": "./helper" }
+    },
+    {
+      "name": "package-imports",
+      "paths": "src/package.ts",
+      "must": { "importFrom": "@scope/pkg" }
+    },
+    {
+      "name": "no-react-imports",
+      "paths": "src/no-react.ts",
+      "mustNot": { "importFrom": "react" }
+    }
+  ]
+}

--- a/e2e/fixtures/import-from-broken/src/no-react.ts
+++ b/e2e/fixtures/import-from-broken/src/no-react.ts
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const react = React;

--- a/e2e/fixtures/import-from-broken/src/package.ts
+++ b/e2e/fixtures/import-from-broken/src/package.ts
@@ -1,0 +1,3 @@
+import { tool } from "@scope/pkg-extra";
+
+export const packageTool = tool;

--- a/e2e/fixtures/import-from-broken/src/path.ts
+++ b/e2e/fixtures/import-from-broken/src/path.ts
@@ -1,0 +1,3 @@
+import "./setup";
+
+export const pathMissing = true;

--- a/e2e/fixtures/import-from/konsistent.json
+++ b/e2e/fixtures/import-from/konsistent.json
@@ -1,0 +1,20 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "path-imports",
+      "paths": "src/path.ts",
+      "must": { "importFrom": "./helper" }
+    },
+    {
+      "name": "package-imports",
+      "paths": "src/package.ts",
+      "must": { "importFrom": "@scope/pkg" }
+    },
+    {
+      "name": "no-react-imports",
+      "paths": "src/no-react.ts",
+      "mustNot": { "importFrom": "react" }
+    }
+  ]
+}

--- a/e2e/fixtures/import-from/src/helper.ts
+++ b/e2e/fixtures/import-from/src/helper.ts
@@ -1,0 +1,1 @@
+export const helper = true;

--- a/e2e/fixtures/import-from/src/no-react.ts
+++ b/e2e/fixtures/import-from/src/no-react.ts
@@ -1,0 +1,3 @@
+import { render } from "react-dom";
+
+export const noReact = render;

--- a/e2e/fixtures/import-from/src/package.ts
+++ b/e2e/fixtures/import-from/src/package.ts
@@ -1,0 +1,3 @@
+import type { Tool } from "@scope/pkg/tools";
+
+export type PackageTool = Tool;

--- a/e2e/fixtures/import-from/src/path.ts
+++ b/e2e/fixtures/import-from/src/path.ts
@@ -1,0 +1,3 @@
+import "./helper";
+
+export const pathOk = true;

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -115,3 +115,28 @@ describe("import-source-groups-broken fixture", () => {
     }
   });
 });
+
+describe("import-from fixture", () => {
+  const cwd = resolve(fixturesDir, "import-from");
+
+  it("konsistent check exits 0 when importFrom predicates pass", async () => {
+    await expect(runCli({ cwd })).resolves.not.toThrow();
+  });
+});
+
+describe("import-from-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "import-from-broken");
+
+  it("konsistent check exits 1 with importFrom violations", async () => {
+    try {
+      await runCli({ cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stdout: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain('Missing import from "./helper"');
+      expect(error.stdout).toContain('Missing import from "@scope/pkg"');
+      expect(error.stdout).toContain('Forbidden import from "react"');
+    }
+  });
+});

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -502,6 +502,9 @@
                       ]
                     }
                   },
+                  "importFrom": {
+                    "type": "string"
+                  },
                   "importTypes": {
                     "type": "array",
                     "items": {
@@ -969,6 +972,9 @@
                         }
                       ]
                     }
+                  },
+                  "importFrom": {
+                    "type": "string"
                   },
                   "importTypes": {
                     "type": "array",
@@ -1519,6 +1525,9 @@
                       ]
                     }
                   },
+                  "importFrom": {
+                    "type": "string"
+                  },
                   "importTypes": {
                     "type": "array",
                     "items": {
@@ -1986,6 +1995,9 @@
                         }
                       ]
                     }
+                  },
+                  "importFrom": {
+                    "type": "string"
                   },
                   "importTypes": {
                     "type": "array",

--- a/packages/convention/src/index.test.ts
+++ b/packages/convention/src/index.test.ts
@@ -64,6 +64,7 @@ describe("ReusableConventionV1Schema", () => {
           },
         ],
         useDeclarationOrder: ["localValue", "createLocal"],
+        importFrom: "react",
         importFromCurrentDir: true,
         importFromParents: false,
         importFromExternals: true,

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -78,6 +78,7 @@ export const MustPredicatesV1Schema = z.strictObject({
     .array(z.union([z.string(), ClassDefinitionV1Schema]))
     .optional(),
   import: z.array(z.union([z.string(), ImportDefinitionV1Schema])).optional(),
+  importFrom: z.string().optional(),
   importTypes: z
     .array(z.union([z.string(), ImportDefinitionV1Schema]))
     .optional(),

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -545,6 +545,9 @@
                       ]
                     }
                   },
+                  "importFrom": {
+                    "type": "string"
+                  },
                   "importTypes": {
                     "type": "array",
                     "items": {
@@ -1012,6 +1015,9 @@
                         }
                       ]
                     }
+                  },
+                  "importFrom": {
+                    "type": "string"
                   },
                   "importTypes": {
                     "type": "array",
@@ -1534,6 +1540,9 @@
                               ]
                             }
                           },
+                          "importFrom": {
+                            "type": "string"
+                          },
                           "importTypes": {
                             "type": "array",
                             "items": {
@@ -2072,6 +2081,9 @@
                                             ]
                                           }
                                         },
+                                        "importFrom": {
+                                          "type": "string"
+                                        },
                                         "importTypes": {
                                           "type": "array",
                                           "items": {
@@ -2539,6 +2551,9 @@
                                               }
                                             ]
                                           }
+                                        },
+                                        "importFrom": {
+                                          "type": "string"
                                         },
                                         "importTypes": {
                                           "type": "array",
@@ -3072,6 +3087,9 @@
                                             ]
                                           }
                                         },
+                                        "importFrom": {
+                                          "type": "string"
+                                        },
                                         "importTypes": {
                                           "type": "array",
                                           "items": {
@@ -3539,6 +3557,9 @@
                                               }
                                             ]
                                           }
+                                        },
+                                        "importFrom": {
+                                          "type": "string"
                                         },
                                         "importTypes": {
                                           "type": "array",
@@ -4078,6 +4099,9 @@
                                         ]
                                       }
                                     },
+                                    "importFrom": {
+                                      "type": "string"
+                                    },
                                     "importTypes": {
                                       "type": "array",
                                       "items": {
@@ -4545,6 +4569,9 @@
                                           }
                                         ]
                                       }
+                                    },
+                                    "importFrom": {
+                                      "type": "string"
                                     },
                                     "importTypes": {
                                       "type": "array",
@@ -5022,6 +5049,9 @@
                             }
                           ]
                         }
+                      },
+                      "importFrom": {
+                        "type": "string"
                       },
                       "importTypes": {
                         "type": "array",
@@ -5542,6 +5572,9 @@
                               ]
                             }
                           },
+                          "importFrom": {
+                            "type": "string"
+                          },
                           "importTypes": {
                             "type": "array",
                             "items": {
@@ -6080,6 +6113,9 @@
                                             ]
                                           }
                                         },
+                                        "importFrom": {
+                                          "type": "string"
+                                        },
                                         "importTypes": {
                                           "type": "array",
                                           "items": {
@@ -6547,6 +6583,9 @@
                                               }
                                             ]
                                           }
+                                        },
+                                        "importFrom": {
+                                          "type": "string"
                                         },
                                         "importTypes": {
                                           "type": "array",
@@ -7080,6 +7119,9 @@
                                             ]
                                           }
                                         },
+                                        "importFrom": {
+                                          "type": "string"
+                                        },
                                         "importTypes": {
                                           "type": "array",
                                           "items": {
@@ -7547,6 +7589,9 @@
                                               }
                                             ]
                                           }
+                                        },
+                                        "importFrom": {
+                                          "type": "string"
                                         },
                                         "importTypes": {
                                           "type": "array",
@@ -8086,6 +8131,9 @@
                                         ]
                                       }
                                     },
+                                    "importFrom": {
+                                      "type": "string"
+                                    },
                                     "importTypes": {
                                       "type": "array",
                                       "items": {
@@ -8553,6 +8601,9 @@
                                           }
                                         ]
                                       }
+                                    },
+                                    "importFrom": {
+                                      "type": "string"
                                     },
                                     "importTypes": {
                                       "type": "array",
@@ -9030,6 +9081,9 @@
                             }
                           ]
                         }
+                      },
+                      "importFrom": {
+                        "type": "string"
                       },
                       "importTypes": {
                         "type": "array",

--- a/packages/konsistent/src/config/placeholder-validator.test.ts
+++ b/packages/konsistent/src/config/placeholder-validator.test.ts
@@ -378,6 +378,27 @@ describe("validatePlaceholders", () => {
     }
   });
 
+  it("detects placeholders inside importFrom", () => {
+    const conventions: ConventionV1[] = [
+      {
+        name: "imports",
+        paths: ["src/{x}"],
+        must: { importFrom: "@scope/${missingPackage}" },
+      },
+    ];
+
+    const result = validatePlaceholders({
+      conventions,
+      identifiers: ["imports"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('"${missingPackage}"');
+      expect(result.error).toContain("must.importFrom");
+    }
+  });
+
   it("treats placeholders declared in for.files as in-scope for the block's predicates", () => {
     const conventions: ConventionV1[] = [
       {

--- a/packages/konsistent/src/config/placeholder-validator.ts
+++ b/packages/konsistent/src/config/placeholder-validator.ts
@@ -309,6 +309,14 @@ function collectUsagesInPredicates(opts: {
     declared,
     usages,
   });
+  if (predicates.importFrom) {
+    pushStringUsages({
+      value: predicates.importFrom,
+      key: `${prefix}.importFrom`,
+      declared,
+      usages,
+    });
+  }
   collectUsagesInDefinitionList({
     list: predicates.importTypes,
     key: `${prefix}.importTypes`,

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -128,6 +128,7 @@ describe("ConfigV1Schema", () => {
           paths: "src/*.ts",
           must: {
             useDeclarationOrder: ["alpha", "beta"],
+            importFrom: "react",
             importFromCurrentDir: true,
             importFromParents: false,
             importFromExternals: true,
@@ -139,6 +140,19 @@ describe("ConfigV1Schema", () => {
       ],
     });
     expect(result.success).toBe(true);
+  });
+
+  it("rejects importFrom when it is not a string", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: { importFrom: ["react"] },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects config with missing version", () => {

--- a/packages/konsistent/src/core/convention-name.test.ts
+++ b/packages/konsistent/src/core/convention-name.test.ts
@@ -224,6 +224,24 @@ describe("generateConventionName", () => {
     });
   });
 
+  describe("importFrom", () => {
+    it("generates must-import-from-{source-kebab}", () => {
+      expect(
+        generateConventionName({
+          must: { importFrom: "@ai-sdk/react" },
+        })
+      ).toBe("must-import-from-ai-sdk-react");
+    });
+
+    it("strips template expressions from sources", () => {
+      expect(
+        generateConventionName({
+          must: { importFrom: "@scope/${packageName}" },
+        })
+      ).toBe("must-import-from-scope");
+    });
+  });
+
   describe("importTypes", () => {
     it("generates must-import-{name-kebab}-type", () => {
       expect(
@@ -298,6 +316,11 @@ describe("generateConventionName", () => {
           mustNot: { importTypesFromCurrentDir: false },
         })
       ).toBe("must-import-type-from-current-dir");
+      expect(
+        generateConventionName({
+          mustNot: { importFrom: "react" },
+        })
+      ).toBe("must-not-import-from-react");
     });
   });
 

--- a/packages/konsistent/src/core/convention-name.ts
+++ b/packages/konsistent/src/core/convention-name.ts
@@ -18,6 +18,16 @@ function fileToKebab(file: string): string {
   return file.replace(/[./]/g, "-").replace(/^-+|-+$/g, "");
 }
 
+function sourceToKebab(source: string): string {
+  const stripped = stripTemplateExpressions(source);
+  return stripped
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .toLowerCase()
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 function getItemName(item: string | { name: string }): string {
   return typeof item === "string" ? item : item.name;
 }
@@ -115,6 +125,11 @@ const PREDICATE_RULES: Record<
       getItemName(items[0] as string | { name: string })
     );
     const prefix = negated ? "must-not-import" : "must-import";
+    return kebab ? `${prefix}-${kebab}` : prefix;
+  },
+  importFrom: ({ items, negated }) => {
+    const kebab = sourceToKebab(items[0] as string);
+    const prefix = negated ? "must-not-import-from" : "must-import-from";
     return kebab ? `${prefix}-${kebab}` : prefix;
   },
   importTypes: ({ items, negated }) => {

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -203,6 +203,29 @@ describe("run", () => {
     expect(diagnostics[0].message).toBe('Forbidden constant export "debug"');
   });
 
+  it("reports diagnostics when mustNot importFrom matches", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: { importFrom: "react" },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        ["src/module.ts", "import { jsx } from 'react/jsx-runtime';"],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].predicateName).toBe("mustNot.importFrom");
+    expect(diagnostics[0].message).toBe('Forbidden import from "react"');
+  });
+
   it("applies block metadata to mustNot predicates", async () => {
     const config: ConfigV1 = {
       version: "v1",

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -20,6 +20,7 @@ import { checkExportFunctions } from "../typescript/predicates/export-functions.
 import { checkExportInterfaces } from "../typescript/predicates/export-interfaces.js";
 import { checkExportTypes } from "../typescript/predicates/export-types.js";
 import { checkImport } from "../typescript/predicates/import.js";
+import { checkImportFrom } from "../typescript/predicates/import-from.js";
 import { checkImportSource } from "../typescript/predicates/import-source.js";
 import { checkImportTypes } from "../typescript/predicates/import-types.js";
 import { checkUseDeclarationOrder } from "../typescript/predicates/use-declaration-order.js";
@@ -76,6 +77,7 @@ export const TS_PREDICATES = new Set([
   "exportClasses",
   "exportInterfaces",
   "import",
+  "importFrom",
   "importTypes",
   "importFromCurrentDir",
   "importFromParents",
@@ -414,6 +416,16 @@ const TS_PREDICATE_HANDLERS: Record<
           severity,
         })
       : [],
+  importFrom: ({ must, context, fileStructure, conventionName, severity }) =>
+    must.importFrom === undefined
+      ? []
+      : checkImportFrom({
+          expected: must.importFrom,
+          context,
+          fileStructure,
+          conventionName,
+          severity,
+        }),
   importTypes: ({ must, context, fileStructure, conventionName, severity }) =>
     must.importTypes
       ? checkImportTypes({
@@ -676,6 +688,8 @@ function formatForbiddenMessage(opts: {
       return `Forbidden class export "${name}"`;
     case "import":
       return `Forbidden import "${name}"`;
+    case "importFrom":
+      return `Forbidden import from "${context.resolveTemplate(String(value))}"`;
     case "importTypes":
       return `Forbidden type import "${name}"`;
     case "importFromCurrentDir":

--- a/packages/konsistent/src/typescript/predicates/import-from.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import-from.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
+import { checkImportFrom } from "./import-from.js";
+
+function createMockContext(opts: {
+  path: string;
+  placeholders?: Record<string, { toString(): string }>;
+}): PredicateContext {
+  const placeholders = opts.placeholders ?? {};
+  return {
+    path: opts.path,
+    placeholders: placeholders as PredicateContext["placeholders"],
+    resolveTemplate(t: string): string {
+      return t.replace(/\$\{(\w+)\}/g, (_match, name) => {
+        const ph = placeholders[name];
+        return ph ? ph.toString() : _match;
+      });
+    },
+    fileExists: () => false,
+    readDir: () => [],
+  };
+}
+
+function parseSource(opts: { source: string }) {
+  return parseFileStructure({ source: opts.source, filePath: "src/index.ts" });
+}
+
+describe("checkImportFrom", () => {
+  it("matches exact relative import sources", () => {
+    const result = checkImportFrom({
+      expected: "./helper",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({ source: "import './helper';" }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns a diagnostic when the import source is missing", () => {
+    const result = checkImportFrom({
+      expected: "./helper",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({ source: "import './setup';" }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('Missing import from "./helper"');
+    expect(result[0].predicateName).toBe("importFrom");
+    expect(result[0].filePath).toBe("src/index.ts");
+  });
+
+  it("matches package subpaths from an unscoped package root", () => {
+    const result = checkImportFrom({
+      expected: "react",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "import { jsx } from 'react/jsx-runtime';",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("matches package subpaths from a scoped package root", () => {
+    const result = checkImportFrom({
+      expected: "@scope/pkg",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "import { tool } from '@scope/pkg/tools';",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("does not match similarly named packages", () => {
+    const result = checkImportFrom({
+      expected: "react",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "import { render } from 'react-dom';",
+      }),
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it("treats package subpaths as exact sources", () => {
+    const result = checkImportFrom({
+      expected: "@scope/pkg/tools",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "import { helper } from '@scope/pkg/tools/helper';",
+      }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('Missing import from "@scope/pkg/tools"');
+  });
+
+  it("matches type-only import statements", () => {
+    const result = checkImportFrom({
+      expected: "@scope/pkg",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "import type { Tool } from '@scope/pkg';",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("resolves template placeholders in the source", () => {
+    const result = checkImportFrom({
+      expected: "@scope/${packageName}",
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { packageName: { toString: () => "pkg" } },
+      }),
+      fileStructure: parseSource({
+        source: "import { tool } from '@scope/pkg/tools';",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("includes conventionName when provided", () => {
+    const result = checkImportFrom({
+      expected: "react",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({ source: "" }),
+      conventionName: "react-files",
+    });
+    expect(result[0].conventionName).toBe("react-files");
+  });
+});

--- a/packages/konsistent/src/typescript/predicates/import-from.ts
+++ b/packages/konsistent/src/typescript/predicates/import-from.ts
@@ -1,0 +1,67 @@
+import type { PredicateContext } from "../../core/context.js";
+import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
+import { createDiagnostic } from "../../core/diagnostics.js";
+import type { FileStructure } from "../types.js";
+
+function isRelativeOrAbsoluteSpecifier(value: string): boolean {
+  return (
+    value === "." ||
+    value === ".." ||
+    value.startsWith("./") ||
+    value.startsWith("../") ||
+    value.startsWith("/")
+  );
+}
+
+function isPackageRootSpecifier(value: string): boolean {
+  if (isRelativeOrAbsoluteSpecifier(value)) {
+    return false;
+  }
+  if (value.startsWith("@")) {
+    const parts = value.split("/");
+    return parts.length === 2 && parts[0].length > 1 && parts[1] !== "";
+  }
+  return !value.includes("/");
+}
+
+function doesImportSourceMatch(opts: {
+  from: string;
+  expected: string;
+}): boolean {
+  const { from, expected } = opts;
+  if (from === expected) {
+    return true;
+  }
+  if (!isPackageRootSpecifier(expected)) {
+    return false;
+  }
+  return from.startsWith(`${expected}/`);
+}
+
+export function checkImportFrom(opts: {
+  expected: string;
+  context: PredicateContext;
+  fileStructure: FileStructure;
+  conventionName?: string;
+  severity?: DiagnosticSeverity;
+}): Diagnostic[] {
+  const { expected, context, fileStructure, conventionName, severity } = opts;
+  const resolvedFrom = context.resolveTemplate(expected);
+  const found = fileStructure.importSources.find((source) =>
+    doesImportSourceMatch({ from: source.from, expected: resolvedFrom })
+  );
+
+  if (found) {
+    return [];
+  }
+
+  return [
+    createDiagnostic({
+      filePath: context.path,
+      predicateName: "importFrom",
+      message: `Missing import from "${resolvedFrom}"`,
+      conventionName,
+      severity,
+    }),
+  ];
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new `importFrom` predicate that checks for a specific import location or package, regardless of _what_ is imported from there.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)