### PR TITLE
feat(konsistent): allow enforcing types for declared or exported constants

### DIFF
--- a/.changeset/tame-buttons-rush.md
+++ b/.changeset/tame-buttons-rush.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): allow enforcing types for declared or exported constants

--- a/docs/guides/fixing-violations.md
+++ b/docs/guides/fixing-violations.md
@@ -155,6 +155,8 @@ Search first: grep for `X`, case variants, stripped variants (`createX` ↔ `X`,
 
 For `exportConstants`, the value must be a `const`. If a `let` or `function` exists under the right name, conversion to `const` is safe only if there are no reassignments — verify by grepping.
 
+When a constant entry includes `schema`, the constant must also have a matching explicit type annotation. Add or adjust the annotation only after confirming the initializer and all assignments satisfy it. Schema checks support scalar, literal-union enum, homogeneous scalar array, and inline object annotations; they do not infer initializer types or resolve named types.
+
 #### `exportTypes`
 
 Message: `Missing export type "X"`.

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -104,10 +104,15 @@ Assert local type declarations. Interfaces and type aliases qualify.
 
 ### `declareConstants`
 
-Assert local `const` declarations.
+Assert local `const` declarations. Optionally validate an explicit type
+annotation using the same `schema` field as `exportConstants`.
 
 ```json
-"must": { "declareConstants": ["DEFAULT_OPTIONS"] }
+"must": {
+  "declareConstants": [
+    { "name": "DEFAULT_PORT", "schema": { "type": "number" } }
+  ]
+}
 ```
 
 ### `declareFunctions`
@@ -212,17 +217,59 @@ Same shape as `export`: bare string or `{ name, from? }`.
 
 ### `exportConstants`
 
-Assert `const` exports specifically. Stricter than `export` — a `function` or `let` with the right name will not satisfy this predicate.
+Assert `const` exports specifically. Stricter than `export` — a `function` or `let` with the right name will not satisfy this predicate. An object entry can use `schema` to validate the constant's explicit type annotation.
 
 ```json
 "must": {
-  "exportConstants": ["pluginId", "DEFAULT_CONFIG"]
+  "exportConstants": [
+    "pluginId",
+    {
+      "name": "mode",
+      "schema": {
+        "type": "string",
+        "enum": ["development", "production"]
+      }
+    },
+    {
+      "name": "tags",
+      "schema": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    {
+      "name": "options",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "endpoint": { "type": "string" },
+          "metadata": {}
+        },
+        "required": ["endpoint"],
+        "additionalProperties": false
+      }
+    }
+  ]
 }
 ```
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `name` | string | The constant name. Templates allowed. |
+| `schema` | object | Optional. Supported JSON Schema subset for the constant's explicit type annotation. |
+
+The supported `schema` forms are:
+
+- Scalar: `{ "type": "string" }`, using `string`, `number`, `boolean`, or `null`.
+- Enum: `{ "type": "string", "enum": ["a", "b"] }`. The annotation must contain exactly the configured literal values, although their order does not matter.
+- Array: `{ "type": "array", "items": { "type": "string" } }`. Items must use a scalar schema. `T[]`, `Array<T>`, `readonly T[]`, and `ReadonlyArray<T>` annotations qualify.
+- Object: `{ "type": "object", "properties": { ... }, "required": [...], "additionalProperties": false }`. An empty property schema (`{}`) checks only that the property is permitted or required; a scalar schema also checks its type.
+
+For object schemas, `required` defaults to an empty array and `additionalProperties` defaults to `true`. Required properties must be non-optional in the TypeScript annotation.
+
+This is deliberately a strict subset of JSON Schema. Unsupported keywords and shapes are rejected during configuration validation, including `integer`, `$ref`, combinators, nested object or array schemas, tuple schemas, enum array items, schema-valued `additionalProperties`, and constraints such as `minItems`.
+
+Schema checks require an explicit annotation on a locally declared constant. Inferred types, named type aliases or interfaces, tuples, index signatures, methods, computed properties, nested types, and cross-file re-exports are not resolved. Enum values and property names inside `schema` are literal data and do not expand placeholders.
 
 ### `exportFunctions`
 

--- a/e2e/fixtures/constant-schemas-broken/konsistent.json
+++ b/e2e/fixtures/constant-schemas-broken/konsistent.json
@@ -1,0 +1,41 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "constant-schemas",
+      "paths": "src/constants.ts",
+      "must": {
+        "declareConstants": [
+          { "name": "localPort", "schema": { "type": "number" } }
+        ],
+        "exportConstants": [
+          {
+            "name": "mode",
+            "schema": {
+              "type": "string",
+              "enum": ["development", "production"]
+            }
+          },
+          {
+            "name": "tags",
+            "schema": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          {
+            "name": "options",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" }
+              },
+              "required": ["endpoint"],
+              "additionalProperties": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/constant-schemas-broken/src/constants.ts
+++ b/e2e/fixtures/constant-schemas-broken/src/constants.ts
@@ -1,0 +1,8 @@
+const localPort = 3000;
+
+export const mode: "development" = "development";
+export const tags: number[] = [1];
+export const options: { endpoint: string; retries: number } = {
+  endpoint: "https://example.com",
+  retries: 3,
+};

--- a/e2e/fixtures/constant-schemas/konsistent.json
+++ b/e2e/fixtures/constant-schemas/konsistent.json
@@ -1,0 +1,42 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "constant-schemas",
+      "paths": "src/constants.ts",
+      "must": {
+        "declareConstants": [
+          { "name": "localPort", "schema": { "type": "number" } }
+        ],
+        "exportConstants": [
+          {
+            "name": "mode",
+            "schema": {
+              "type": "string",
+              "enum": ["development", "production"]
+            }
+          },
+          {
+            "name": "tags",
+            "schema": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          {
+            "name": "options",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" },
+                "metadata": {}
+              },
+              "required": ["endpoint"],
+              "additionalProperties": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/constant-schemas/src/constants.ts
+++ b/e2e/fixtures/constant-schemas/src/constants.ts
@@ -1,0 +1,7 @@
+const localPort: number = 3000;
+
+export const mode: "development" | "production" = "development";
+export const tags: readonly string[] = ["stable"];
+export const options: { endpoint: string; metadata?: unknown } = {
+  endpoint: "https://example.com",
+};

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -48,6 +48,40 @@ describe("declaration-predicates-broken fixture", () => {
   });
 });
 
+describe("constant-schemas fixture", () => {
+  const cwd = resolve(fixturesDir, "constant-schemas");
+
+  it("konsistent check exits 0 when constant schemas match", async () => {
+    await expect(runCli({ cwd })).resolves.not.toThrow();
+  });
+});
+
+describe("constant-schemas-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "constant-schemas-broken");
+
+  it("konsistent check exits 1 with constant schema violations", async () => {
+    try {
+      await runCli({ cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stdout: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain(
+        'Constant "localPort" must have an explicit type annotation'
+      );
+      expect(error.stdout).toContain(
+        'Constant "mode" must have exactly the configured enum values'
+      );
+      expect(error.stdout).toContain(
+        'Constant "tags" must be an array with items of type "string"'
+      );
+      expect(error.stdout).toContain(
+        'Constant "options" must not have additional property "retries"'
+      );
+    }
+  });
+});
+
 describe("declaration-order fixture", () => {
   const cwd = resolve(fixturesDir, "declaration-order");
 

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -132,6 +132,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -336,6 +470,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -613,6 +881,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -817,6 +1219,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1175,6 +1711,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1379,6 +2049,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1656,6 +2460,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1860,6 +2798,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],

--- a/packages/convention/src/constant-schema.test.ts
+++ b/packages/convention/src/constant-schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ConstantValueSchemaV1Schema } from "./constant-schema.js";
+
+describe("ConstantValueSchemaV1Schema", () => {
+  it.each([
+    { type: "string" },
+    { type: "number", enum: [1, 2] },
+    { type: "array", items: { type: "boolean" } },
+    {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        metadata: {},
+      },
+      required: ["name"],
+      additionalProperties: false,
+    },
+  ])("accepts supported schema $type", (schema) => {
+    expect(ConstantValueSchemaV1Schema.safeParse(schema).success).toBe(true);
+  });
+
+  it.each([
+    { type: "integer" },
+    { type: "string", enum: [] },
+    { type: "string", enum: ["a", "a"] },
+    { type: "string", enum: ["a", 1] },
+    { type: "array" },
+    { type: "array", items: { type: "object" } },
+    { type: "array", items: { type: "string", enum: ["a"] } },
+    { type: "array", items: { type: "string" }, minItems: 1 },
+    {
+      type: "object",
+      properties: { child: { type: "object" } },
+    },
+    {
+      type: "object",
+      properties: { name: {} },
+      required: ["missing"],
+    },
+    {
+      type: "object",
+      properties: { name: {} },
+      required: ["name", "name"],
+    },
+    {
+      type: "object",
+      properties: {},
+      additionalProperties: { type: "string" },
+    },
+    { type: "string", oneOf: [{ type: "string" }] },
+  ])("rejects unsupported schema %#", (schema) => {
+    expect(ConstantValueSchemaV1Schema.safeParse(schema).success).toBe(false);
+  });
+});

--- a/packages/convention/src/constant-schema.ts
+++ b/packages/convention/src/constant-schema.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+export const ConstantScalarTypeV1Schema = z.enum([
+  "string",
+  "number",
+  "boolean",
+  "null",
+]);
+
+const ConstantScalarValueV1Schema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+export const ConstantScalarSchemaV1Schema = z.strictObject({
+  type: ConstantScalarTypeV1Schema,
+});
+
+export const ConstantEnumSchemaV1Schema = z
+  .strictObject({
+    type: ConstantScalarTypeV1Schema,
+    enum: z.array(ConstantScalarValueV1Schema).min(1),
+  })
+  .superRefine((schema, context) => {
+    const seen = new Set<string>();
+
+    for (const [index, value] of schema.enum.entries()) {
+      const valueType = value === null ? "null" : typeof value;
+      if (valueType !== schema.type) {
+        context.addIssue({
+          code: "custom",
+          path: ["enum", index],
+          message: `Enum value must be of type "${schema.type}"`,
+        });
+      }
+
+      const key = `${valueType}:${String(value)}`;
+      if (seen.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["enum", index],
+          message: "Enum values must be unique",
+        });
+      }
+      seen.add(key);
+    }
+  });
+
+const ConstantObjectPropertySchemaV1Schema = z.union([
+  z.strictObject({}),
+  ConstantScalarSchemaV1Schema,
+]);
+
+export const ConstantArraySchemaV1Schema = z.strictObject({
+  type: z.literal("array"),
+  items: ConstantScalarSchemaV1Schema,
+});
+
+export const ConstantObjectSchemaV1Schema = z
+  .strictObject({
+    type: z.literal("object"),
+    properties: z.record(z.string(), ConstantObjectPropertySchemaV1Schema),
+    required: z.array(z.string()).optional(),
+    additionalProperties: z.boolean().optional(),
+  })
+  .superRefine((schema, context) => {
+    const seen = new Set<string>();
+
+    for (const [index, name] of (schema.required ?? []).entries()) {
+      if (seen.has(name)) {
+        context.addIssue({
+          code: "custom",
+          path: ["required", index],
+          message: "Required property names must be unique",
+        });
+      }
+      seen.add(name);
+
+      if (!Object.hasOwn(schema.properties, name)) {
+        context.addIssue({
+          code: "custom",
+          path: ["required", index],
+          message: `Required property "${name}" must be defined in properties`,
+        });
+      }
+    }
+  });
+
+export const ConstantValueSchemaV1Schema = z.union([
+  ConstantEnumSchemaV1Schema,
+  ConstantArraySchemaV1Schema,
+  ConstantObjectSchemaV1Schema,
+  ConstantScalarSchemaV1Schema,
+]);
+
+export const ConstantDefinitionV1Schema = z.strictObject({
+  name: z.string(),
+  schema: ConstantValueSchemaV1Schema.optional(),
+});
+
+export const ExportConstantDefinitionV1Schema = z.strictObject({
+  name: z.string(),
+  from: z.string().optional(),
+  schema: ConstantValueSchemaV1Schema.optional(),
+});
+
+export type ConstantScalarTypeV1 = z.infer<typeof ConstantScalarTypeV1Schema>;
+export type ConstantScalarSchemaV1 = z.infer<
+  typeof ConstantScalarSchemaV1Schema
+>;
+export type ConstantEnumSchemaV1 = z.infer<typeof ConstantEnumSchemaV1Schema>;
+export type ConstantArraySchemaV1 = z.infer<typeof ConstantArraySchemaV1Schema>;
+export type ConstantObjectSchemaV1 = z.infer<
+  typeof ConstantObjectSchemaV1Schema
+>;
+export type ConstantValueSchemaV1 = z.infer<typeof ConstantValueSchemaV1Schema>;
+export type ConstantDefinitionV1 = z.infer<typeof ConstantDefinitionV1Schema>;
+export type ExportConstantDefinitionV1 = z.infer<
+  typeof ExportConstantDefinitionV1Schema
+>;

--- a/packages/convention/src/index.ts
+++ b/packages/convention/src/index.ts
@@ -1,6 +1,26 @@
 import type { ReusableConventionV1 } from "./schemas.js";
 
 export type {
+  ConstantArraySchemaV1,
+  ConstantDefinitionV1,
+  ConstantEnumSchemaV1,
+  ConstantObjectSchemaV1,
+  ConstantScalarSchemaV1,
+  ConstantScalarTypeV1,
+  ConstantValueSchemaV1,
+  ExportConstantDefinitionV1,
+} from "./constant-schema.js";
+export {
+  ConstantArraySchemaV1Schema,
+  ConstantDefinitionV1Schema,
+  ConstantEnumSchemaV1Schema,
+  ConstantObjectSchemaV1Schema,
+  ConstantScalarSchemaV1Schema,
+  ConstantScalarTypeV1Schema,
+  ConstantValueSchemaV1Schema,
+  ExportConstantDefinitionV1Schema,
+} from "./constant-schema.js";
+export type {
   ClassDefinitionV1,
   DeclarationDefinitionV1,
   ExportDefinitionV1,

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  ConstantDefinitionV1Schema,
+  ExportConstantDefinitionV1Schema,
+} from "./constant-schema.js";
 
 export const ExportDefinitionV1Schema = z.strictObject({
   name: z.string(),
@@ -50,7 +54,7 @@ export const MustPredicatesV1Schema = z.strictObject({
     .array(z.union([z.string(), DeclarationDefinitionV1Schema]))
     .optional(),
   declareConstants: z
-    .array(z.union([z.string(), DeclarationDefinitionV1Schema]))
+    .array(z.union([z.string(), ConstantDefinitionV1Schema]))
     .optional(),
   declareFunctions: z
     .array(z.union([z.string(), FunctionDefinitionV1Schema]))
@@ -66,7 +70,7 @@ export const MustPredicatesV1Schema = z.strictObject({
     .array(z.union([z.string(), ExportDefinitionV1Schema]))
     .optional(),
   exportConstants: z
-    .array(z.union([z.string(), ExportDefinitionV1Schema]))
+    .array(z.union([z.string(), ExportConstantDefinitionV1Schema]))
     .optional(),
   exportFunctions: z
     .array(z.union([z.string(), FunctionDefinitionV1Schema]))

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -175,6 +175,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -379,6 +513,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -656,6 +924,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -860,6 +1262,140 @@
                             },
                             "from": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1190,6 +1726,140 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["type", "enum"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["type"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["type", "items"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["type", "properties"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
                                   "required": ["name"],
@@ -1394,6 +2064,140 @@
                                     },
                                     "from": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["type", "enum"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["type"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["type", "items"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["type", "properties"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
                                   "required": ["name"],
@@ -1741,6 +2545,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -1945,6 +2896,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -2222,6 +3320,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -2426,6 +3671,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -2767,6 +4159,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -2971,6 +4510,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -3248,6 +4934,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -3452,6 +5285,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -3799,6 +5779,151 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -4003,6 +6128,151 @@
                                               },
                                               "from": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -4280,6 +6550,151 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -4484,6 +6899,151 @@
                                               },
                                               "from": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -4770,6 +7330,140 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
                               "required": ["name"],
@@ -4974,6 +7668,140 @@
                                 },
                                 "from": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
                               "required": ["name"],
@@ -5302,6 +8130,140 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["type", "enum"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["type"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["type", "items"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["type", "properties"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
                                   "required": ["name"],
@@ -5506,6 +8468,140 @@
                                     },
                                     "from": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": ["type", "enum"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": ["type"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["type", "items"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["type", "properties"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
                                   "required": ["name"],
@@ -5853,6 +8949,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -6057,6 +9300,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -6334,6 +9724,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -6538,6 +10075,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -6879,6 +10563,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -7083,6 +10914,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -7360,6 +11338,153 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -7564,6 +11689,153 @@
                                                   },
                                                   "from": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
                                                 "required": ["name"],
@@ -7911,6 +12183,151 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -8115,6 +12532,151 @@
                                               },
                                               "from": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -8392,6 +12954,151 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -8596,6 +13303,151 @@
                                               },
                                               "from": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": ["type"],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": ["type"],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
                                             "required": ["name"],
@@ -8882,6 +13734,140 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
                               "required": ["name"],
@@ -9086,6 +14072,140 @@
                                 },
                                 "from": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
                               "required": ["name"],

--- a/packages/konsistent/src/config/schema.ts
+++ b/packages/konsistent/src/config/schema.ts
@@ -6,7 +6,15 @@ import { z } from "zod";
 
 export type {
   ClassDefinitionV1,
+  ConstantArraySchemaV1,
+  ConstantDefinitionV1,
+  ConstantEnumSchemaV1,
+  ConstantObjectSchemaV1,
+  ConstantScalarSchemaV1,
+  ConstantScalarTypeV1,
+  ConstantValueSchemaV1,
   DeclarationDefinitionV1,
+  ExportConstantDefinitionV1,
   ExportDefinitionV1,
   FunctionDefinitionV1,
   ImportDefinitionV1,
@@ -18,7 +26,15 @@ export type {
 } from "@konsistent/convention";
 export {
   ClassDefinitionV1Schema,
+  ConstantArraySchemaV1Schema,
+  ConstantDefinitionV1Schema,
+  ConstantEnumSchemaV1Schema,
+  ConstantObjectSchemaV1Schema,
+  ConstantScalarSchemaV1Schema,
+  ConstantScalarTypeV1Schema,
+  ConstantValueSchemaV1Schema,
   DeclarationDefinitionV1Schema,
+  ExportConstantDefinitionV1Schema,
   ExportDefinitionV1Schema,
   FunctionDefinitionV1Schema,
   ImportDefinitionV1Schema,

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -203,6 +203,54 @@ describe("run", () => {
     expect(diagnostics[0].message).toBe('Forbidden constant export "debug"');
   });
 
+  it("forbids a constant matching a mustNot schema", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            exportConstants: [{ name: "debug", schema: { type: "boolean" } }],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        ["src/module.ts", "export const debug: boolean = true;"],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].predicateName).toBe("mustNot.exportConstants");
+    expect(diagnostics[0].message).toBe('Forbidden constant export "debug"');
+  });
+
+  it("allows a mustNot constant with a different schema", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            exportConstants: [{ name: "debug", schema: { type: "boolean" } }],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        ["src/module.ts", 'export const debug: string = "true";'],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toEqual([]);
+  });
+
   it("returns no diagnostics when mustNot importFrom does not match a subpath", async () => {
     const config: ConfigV1 = {
       version: "v1",

--- a/packages/konsistent/src/typescript/constant-type-schema.test.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.test.ts
@@ -1,0 +1,173 @@
+import type { ConstantValueSchemaV1 } from "@konsistent/convention";
+import { describe, expect, it } from "vitest";
+import { matchConstantTypeSchema } from "./constant-type-schema.js";
+import { parseFileStructure } from "./parser.js";
+
+function getTypeInfo(opts: { type: string }) {
+  return parseFileStructure({ source: `const value: ${opts.type} = null;` })
+    .constants[0].typeInfo;
+}
+
+function matches(opts: {
+  type: string;
+  schema: ConstantValueSchemaV1;
+}): boolean {
+  return matchConstantTypeSchema({
+    actual: getTypeInfo({ type: opts.type }),
+    schema: opts.schema,
+  }).matches;
+}
+
+describe("constant type schemas", () => {
+  it.each([
+    "string",
+    "number",
+    "boolean",
+    "null",
+  ])("matches the %s scalar type", (type) => {
+    expect(
+      matches({
+        type,
+        schema: { type: type as "string" },
+      })
+    ).toBe(true);
+  });
+
+  it("requires scalar types to match exactly", () => {
+    expect(matches({ type: '"value"', schema: { type: "string" } })).toBe(
+      false
+    );
+  });
+
+  it("matches exact homogeneous enum values regardless of order", () => {
+    expect(
+      matches({
+        type: '"production" | "development"',
+        schema: {
+          type: "string",
+          enum: ["development", "production"],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("matches a null enum", () => {
+    expect(
+      matches({ type: "null", schema: { type: "null", enum: [null] } })
+    ).toBe(true);
+  });
+
+  it("rejects enum omissions and additions", () => {
+    const schema = {
+      type: "string" as const,
+      enum: ["development", "production"],
+    };
+    expect(matches({ type: '"development"', schema })).toBe(false);
+    expect(
+      matches({ type: '"development" | "production" | "test"', schema })
+    ).toBe(false);
+  });
+
+  it.each([
+    "string[]",
+    "Array<string>",
+    "readonly string[]",
+    "ReadonlyArray<string>",
+  ])("matches the supported array annotation %s", (type) => {
+    expect(
+      matches({ type, schema: { type: "array", items: { type: "string" } } })
+    ).toBe(true);
+  });
+
+  it.each([
+    "number[]",
+    "[string, string]",
+    'Array<"value">',
+  ])("rejects non-matching or unsupported array annotation %s", (type) => {
+    expect(
+      matches({
+        type,
+        schema: { type: "array", items: { type: "string" } },
+      })
+    ).toBe(false);
+  });
+
+  it("matches required, optional, typed, and unconstrained properties", () => {
+    expect(
+      matches({
+        type: "{ name: string; enabled?: boolean; metadata: unknown }",
+        schema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            enabled: { type: "boolean" },
+            metadata: {},
+          },
+          required: ["name", "metadata"],
+          additionalProperties: false,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("matches quoted empty property names", () => {
+    expect(
+      matches({
+        type: '{ "": string }',
+        schema: {
+          type: "object",
+          properties: { "": { type: "string" } },
+          required: [""],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("enforces required and additional object properties", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { name: { type: "string" as const } },
+      required: ["name"],
+      additionalProperties: false,
+    };
+    expect(matches({ type: "{ name?: string }", schema })).toBe(false);
+    expect(matches({ type: "{ name: string; extra: number }", schema })).toBe(
+      false
+    );
+  });
+
+  it("allows additional properties by default", () => {
+    expect(
+      matches({
+        type: "{ name: string; extra: number }",
+        schema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    "Config",
+    "{ run(): void }",
+    "{ [key: string]: string }",
+  ])("rejects unsupported annotation %s", (type) => {
+    expect(matches({ type, schema: { type: "object", properties: {} } })).toBe(
+      false
+    );
+  });
+
+  it("rejects constants without explicit annotations", () => {
+    const result = matchConstantTypeSchema({
+      actual: parseFileStructure({ source: 'const value = "value";' })
+        .constants[0].typeInfo,
+      schema: { type: "string" },
+    });
+    expect(result).toEqual({
+      matches: false,
+      reason: "must have an explicit type annotation",
+    });
+  });
+});

--- a/packages/konsistent/src/typescript/constant-type-schema.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.ts
@@ -1,0 +1,347 @@
+import type {
+  ConstantScalarTypeV1,
+  ConstantValueSchemaV1,
+} from "@konsistent/convention";
+import ts from "typescript";
+
+type ConstantScalarValue = string | number | boolean | null;
+
+interface ConstantScalarTypeInfo {
+  kind: "scalar";
+  type: ConstantScalarTypeV1;
+}
+
+interface ConstantEnumTypeInfo {
+  kind: "enum";
+  type: ConstantScalarTypeV1;
+  values: ConstantScalarValue[];
+}
+
+interface ConstantArrayTypeInfo {
+  itemType: ConstantScalarTypeV1;
+  kind: "array";
+}
+
+interface ConstantObjectPropertyTypeInfo {
+  name: string;
+  optional: boolean;
+  scalarType?: ConstantScalarTypeV1;
+}
+
+interface ConstantObjectTypeInfo {
+  kind: "object";
+  properties: ConstantObjectPropertyTypeInfo[];
+}
+
+interface UnsupportedConstantTypeInfo {
+  kind: "unsupported";
+}
+
+export type ConstantTypeInfo =
+  | ConstantScalarTypeInfo
+  | ConstantEnumTypeInfo
+  | ConstantArrayTypeInfo
+  | ConstantObjectTypeInfo
+  | UnsupportedConstantTypeInfo;
+
+export interface ConstantSchemaMatchResult {
+  matches: boolean;
+  reason?: string;
+}
+
+function parseScalarType(
+  node: ts.TypeNode | undefined
+): ConstantScalarTypeV1 | undefined {
+  switch (node?.kind) {
+    case ts.SyntaxKind.StringKeyword:
+      return "string";
+    case ts.SyntaxKind.NumberKeyword:
+      return "number";
+    case ts.SyntaxKind.BooleanKeyword:
+      return "boolean";
+    default:
+      if (
+        node &&
+        ts.isLiteralTypeNode(node) &&
+        node.literal.kind === ts.SyntaxKind.NullKeyword
+      ) {
+        return "null";
+      }
+      return;
+  }
+}
+
+function parseLiteralValue(node: ts.TypeNode): ConstantScalarValue | undefined {
+  if (!ts.isLiteralTypeNode(node)) {
+    return;
+  }
+
+  const { literal } = node;
+  if (ts.isStringLiteral(literal)) {
+    return literal.text;
+  }
+  if (ts.isNumericLiteral(literal)) {
+    return Number(literal.text);
+  }
+  if (literal.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (literal.kind === ts.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  if (literal.kind === ts.SyntaxKind.NullKeyword) {
+    return null;
+  }
+  if (
+    ts.isPrefixUnaryExpression(literal) &&
+    literal.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(literal.operand)
+  ) {
+    return -Number(literal.operand.text);
+  }
+  return;
+}
+
+function getScalarValueType(value: ConstantScalarValue): ConstantScalarTypeV1 {
+  return value === null ? "null" : (typeof value as ConstantScalarTypeV1);
+}
+
+function parseEnumType(node: ts.TypeNode): ConstantEnumTypeInfo | undefined {
+  const members = ts.isUnionTypeNode(node) ? node.types : [node];
+  const values: ConstantScalarValue[] = [];
+
+  for (const member of members) {
+    const value = parseLiteralValue(member);
+    if (value === undefined) {
+      return;
+    }
+    values.push(value);
+  }
+
+  const type =
+    values[0] === undefined ? undefined : getScalarValueType(values[0]);
+  if (!(type && values.every((value) => getScalarValueType(value) === type))) {
+    return;
+  }
+  return { kind: "enum", type, values };
+}
+
+function parseArrayType(node: ts.TypeNode): ConstantArrayTypeInfo | undefined {
+  if (ts.isArrayTypeNode(node)) {
+    const itemType = parseScalarType(node.elementType);
+    return itemType ? { kind: "array", itemType } : undefined;
+  }
+
+  if (
+    ts.isTypeOperatorNode(node) &&
+    node.operator === ts.SyntaxKind.ReadonlyKeyword &&
+    ts.isArrayTypeNode(node.type)
+  ) {
+    const itemType = parseScalarType(node.type.elementType);
+    return itemType ? { kind: "array", itemType } : undefined;
+  }
+
+  if (ts.isTypeReferenceNode(node)) {
+    const name = node.typeName.getText();
+    if (
+      (name === "Array" || name === "ReadonlyArray") &&
+      node.typeArguments?.length === 1
+    ) {
+      const itemType = parseScalarType(node.typeArguments[0]);
+      return itemType ? { kind: "array", itemType } : undefined;
+    }
+  }
+
+  return;
+}
+
+function getPropertyName(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return;
+}
+
+function parseObjectType(
+  node: ts.TypeLiteralNode
+): ConstantObjectTypeInfo | undefined {
+  const properties: ConstantObjectPropertyTypeInfo[] = [];
+  const names = new Set<string>();
+
+  for (const member of node.members) {
+    if (!(ts.isPropertySignature(member) && member.name)) {
+      return;
+    }
+    const name = getPropertyName(member.name);
+    if (name === undefined || names.has(name)) {
+      return;
+    }
+    names.add(name);
+    const scalarType = parseScalarType(member.type);
+    properties.push({
+      name,
+      optional: Boolean(member.questionToken),
+      ...(scalarType ? { scalarType } : {}),
+    });
+  }
+
+  return { kind: "object", properties };
+}
+
+export function parseConstantTypeAnnotation(opts: {
+  node: ts.TypeNode | undefined;
+}): ConstantTypeInfo | undefined {
+  const { node } = opts;
+  if (!node) {
+    return;
+  }
+
+  const scalarType = parseScalarType(node);
+  if (scalarType) {
+    return { kind: "scalar", type: scalarType };
+  }
+
+  const enumType = parseEnumType(node);
+  if (enumType) {
+    return enumType;
+  }
+
+  const arrayType = parseArrayType(node);
+  if (arrayType) {
+    return arrayType;
+  }
+
+  if (ts.isTypeLiteralNode(node)) {
+    return parseObjectType(node) ?? { kind: "unsupported" };
+  }
+
+  return { kind: "unsupported" };
+}
+
+function scalarValueKey(value: ConstantScalarValue): string {
+  return `${getScalarValueType(value)}:${String(value)}`;
+}
+
+function matchEnumSchema(opts: {
+  actual: ConstantTypeInfo;
+  schema: Extract<ConstantValueSchemaV1, { enum: unknown }>;
+}): ConstantSchemaMatchResult {
+  const { actual, schema } = opts;
+  if (
+    actual.kind === "scalar" &&
+    actual.type === "null" &&
+    schema.type === "null" &&
+    schema.enum.length === 1 &&
+    schema.enum[0] === null
+  ) {
+    return { matches: true };
+  }
+  if (actual.kind !== "enum" || actual.type !== schema.type) {
+    return {
+      matches: false,
+      reason: `must have the configured ${schema.type} enum type`,
+    };
+  }
+
+  const actualValues = new Set(actual.values.map(scalarValueKey));
+  const expectedValues = new Set(schema.enum.map(scalarValueKey));
+  if (
+    actualValues.size !== expectedValues.size ||
+    [...expectedValues].some((value) => !actualValues.has(value))
+  ) {
+    return {
+      matches: false,
+      reason: "must have exactly the configured enum values",
+    };
+  }
+  return { matches: true };
+}
+
+function matchObjectSchema(opts: {
+  actual: ConstantTypeInfo;
+  schema: Extract<ConstantValueSchemaV1, { type: "object" }>;
+}): ConstantSchemaMatchResult {
+  const { actual, schema } = opts;
+  if (actual.kind !== "object") {
+    return { matches: false, reason: "must have an inline object type" };
+  }
+
+  const actualProperties = new Map(
+    actual.properties.map((property) => [property.name, property])
+  );
+
+  for (const name of schema.required ?? []) {
+    const property = actualProperties.get(name);
+    if (!property) {
+      return {
+        matches: false,
+        reason: `must have required property "${name}"`,
+      };
+    }
+    if (property.optional) {
+      return {
+        matches: false,
+        reason: `property "${name}" must not be optional`,
+      };
+    }
+  }
+
+  for (const [name, propertySchema] of Object.entries(schema.properties)) {
+    const property = actualProperties.get(name);
+    if (!(property && Object.hasOwn(propertySchema, "type"))) {
+      continue;
+    }
+    if (property.scalarType !== propertySchema.type) {
+      return {
+        matches: false,
+        reason: `property "${name}" must be of type "${propertySchema.type}"`,
+      };
+    }
+  }
+
+  if (schema.additionalProperties === false) {
+    const unexpected = actual.properties.find(
+      (property) => !Object.hasOwn(schema.properties, property.name)
+    );
+    if (unexpected) {
+      return {
+        matches: false,
+        reason: `must not have additional property "${unexpected.name}"`,
+      };
+    }
+  }
+
+  return { matches: true };
+}
+
+export function matchConstantTypeSchema(opts: {
+  actual: ConstantTypeInfo | undefined;
+  schema: ConstantValueSchemaV1;
+}): ConstantSchemaMatchResult {
+  const { actual, schema } = opts;
+  if (!actual) {
+    return { matches: false, reason: "must have an explicit type annotation" };
+  }
+  if (actual.kind === "unsupported") {
+    return { matches: false, reason: "uses an unsupported type annotation" };
+  }
+  if (Object.hasOwn(schema, "enum")) {
+    return matchEnumSchema({ actual, schema });
+  }
+  if (schema.type === "array") {
+    if (actual.kind !== "array" || actual.itemType !== schema.items.type) {
+      return {
+        matches: false,
+        reason: `must be an array with items of type "${schema.items.type}"`,
+      };
+    }
+    return { matches: true };
+  }
+  if (schema.type === "object") {
+    return matchObjectSchema({ actual, schema });
+  }
+  if (actual.kind !== "scalar" || actual.type !== schema.type) {
+    return { matches: false, reason: `must be of type "${schema.type}"` };
+  }
+  return { matches: true };
+}

--- a/packages/konsistent/src/typescript/parser.ts
+++ b/packages/konsistent/src/typescript/parser.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { parseConstantTypeAnnotation } from "./constant-type-schema.js";
 import type {
   ClassInfo,
   ConstantInfo,
@@ -418,6 +419,7 @@ function processVariableStatement(opts: {
       const pos = getPosition({ sourceFile, node });
       collector.constants.push({
         name: decl.name.getText(sourceFile),
+        typeInfo: parseConstantTypeAnnotation({ node: decl.type }),
         typeName: extractTypeAnnotation(decl.type),
         pos,
       });

--- a/packages/konsistent/src/typescript/predicates/declare-constants.test.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-constants.test.ts
@@ -43,4 +43,45 @@ describe("checkDeclareConstants", () => {
     );
     expect(result[0].predicateName).toBe("declareConstants");
   });
+
+  it("validates a configured constant schema", () => {
+    const result = checkDeclareConstants({
+      expected: [
+        {
+          name: "modes",
+          schema: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "const modes: readonly string[] = [];",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("reports a mismatched constant schema", () => {
+    const result = checkDeclareConstants({
+      expected: [{ name: "port", schema: { type: "number" } }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({ source: 'const port: string = "3000";' }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('Constant "port" must be of type "number"');
+  });
+
+  it("requires an explicit annotation when a schema is configured", () => {
+    const result = checkDeclareConstants({
+      expected: [{ name: "port", schema: { type: "number" } }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({ source: "const port = 3000;" }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe(
+      'Constant "port" must have an explicit type annotation'
+    );
+  });
 });

--- a/packages/konsistent/src/typescript/predicates/declare-constants.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-constants.ts
@@ -1,5 +1,8 @@
+import type { ConstantDefinitionV1 } from "@konsistent/convention";
 import type { PredicateContext } from "../../core/context.js";
 import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
+import { createDiagnostic } from "../../core/diagnostics.js";
+import { matchConstantTypeSchema } from "../constant-type-schema.js";
 import type { FileStructure } from "../types.js";
 import {
   createExportedDeclarationDiagnostic,
@@ -11,7 +14,7 @@ import {
 } from "./declaration-utils.js";
 
 export function checkDeclareConstants(opts: {
-  expected: (string | { name: string })[];
+  expected: (string | ConstantDefinitionV1)[];
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -27,6 +30,7 @@ export function checkDeclareConstants(opts: {
   };
 
   for (const entry of expected) {
+    const definition = typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = resolveDefinitionName({ entry, context });
     const symbol = findDeclarationSymbol({
       fileStructure,
@@ -53,6 +57,30 @@ export function checkDeclareConstants(opts: {
           symbol,
         })
       );
+      continue;
+    }
+
+    if (definition.schema) {
+      const constantInfo = fileStructure.constants.find(
+        (constant) => constant.name === resolvedName
+      );
+      const result = matchConstantTypeSchema({
+        actual: constantInfo?.typeInfo,
+        schema: definition.schema,
+      });
+      if (!result.matches) {
+        diagnostics.push(
+          createDiagnostic({
+            filePath: context.path,
+            predicateName: "declareConstants",
+            message: `Constant "${resolvedName}" ${result.reason}`,
+            conventionName,
+            line: constantInfo?.pos.line ?? symbol.pos.line,
+            column: constantInfo?.pos.column ?? symbol.pos.column,
+            severity,
+          })
+        );
+      }
     }
   }
 

--- a/packages/konsistent/src/typescript/predicates/export-constants.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
 import type { FileStructure } from "../types.js";
 import { checkExportConstants } from "./export-constants.js";
 
@@ -170,5 +171,50 @@ describe("checkExportConstants", () => {
       conventionName: "const-exports",
     });
     expect(result[0].conventionName).toBe("const-exports");
+  });
+
+  it("validates a configured constant schema", () => {
+    const result = checkExportConstants({
+      expected: [
+        {
+          name: "mode",
+          schema: {
+            type: "string",
+            enum: ["development", "production"],
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source:
+          'export const mode: "development" | "production" = "development";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("reports an object schema mismatch", () => {
+    const result = checkExportConstants({
+      expected: [
+        {
+          name: "options",
+          schema: {
+            type: "object",
+            properties: { endpoint: { type: "string" } },
+            required: ["endpoint"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source:
+          'export const options: { endpoint: string; retries: number } = { endpoint: "", retries: 1 };',
+      }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe(
+      'Constant "options" must not have additional property "retries"'
+    );
   });
 });

--- a/packages/konsistent/src/typescript/predicates/export-constants.ts
+++ b/packages/konsistent/src/typescript/predicates/export-constants.ts
@@ -1,10 +1,12 @@
+import type { ExportConstantDefinitionV1 } from "@konsistent/convention";
 import type { PredicateContext } from "../../core/context.js";
 import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
 import { createDiagnostic } from "../../core/diagnostics.js";
+import { matchConstantTypeSchema } from "../constant-type-schema.js";
 import type { FileStructure } from "../types.js";
 
 export function checkExportConstants(opts: {
-  expected: (string | { name: string })[];
+  expected: (string | ExportConstantDefinitionV1)[];
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -31,6 +33,30 @@ export function checkExportConstants(opts: {
           severity,
         })
       );
+      continue;
+    }
+
+    if (definition.schema) {
+      const constantInfo = fileStructure.constants.find(
+        (constant) => constant.name === resolvedName
+      );
+      const result = matchConstantTypeSchema({
+        actual: constantInfo?.typeInfo,
+        schema: definition.schema,
+      });
+      if (!result.matches) {
+        diagnostics.push(
+          createDiagnostic({
+            filePath: context.path,
+            predicateName: "exportConstants",
+            message: `Constant "${resolvedName}" ${result.reason}`,
+            conventionName,
+            line: constantInfo?.pos.line,
+            column: constantInfo?.pos.column,
+            severity,
+          })
+        );
+      }
     }
   }
 

--- a/packages/konsistent/src/typescript/types.ts
+++ b/packages/konsistent/src/typescript/types.ts
@@ -91,6 +91,7 @@ export interface FunctionInfo {
 export interface ConstantInfo {
   name: string;
   pos: SourcePosition;
+  typeInfo?: ConstantTypeInfo;
   typeName?: TypeAnnotationInfo;
 }
 
@@ -125,3 +126,5 @@ export interface FileStructure {
   nonBarrelStatements: NonBarrelStatementInfo[];
   typeAliases: TypeAliasInfo[];
 }
+
+import type { ConstantTypeInfo } from "./constant-type-schema.js";


### PR DESCRIPTION
## Pull Request Description

Allow conventions to enforce explicit type annotations for locally declared and exported constants using a strict, documented subset of JSON Schema.

## Relevant technical choices

The public schema validation and TypeScript AST matching are kept separate so the convention package remains independent of TypeScript-specific behavior.

- Support scalar, exact enum, homogeneous scalar array, and inline object schemas.
- Reject unsupported JSON Schema keywords and unsupported TypeScript annotation shapes.
- Preserve existing constant predicates when `schema` is omitted.
- Add unit and end-to-end coverage, generated schemas, and reference documentation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
