### PR TITLE
feat(konsistent): validate schemas for declared and exported type definitions

### DIFF
--- a/.changeset/salty-stamps-cover.md
+++ b/.changeset/salty-stamps-cover.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): validate schemas for declared and exported type definitions

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -4,6 +4,7 @@
   "plugins": ["./node_modules/@felixarntz/biome/rules/all.grit"],
   "files": {
     "includes": [
+      "!!packages/konsistent/konsistent.schema.json",
       "!**/e2e/fixtures",
       "!**/agent-artifacts",
       "!**/.pnpm-store",

--- a/docs/guides/fixing-violations.md
+++ b/docs/guides/fixing-violations.md
@@ -155,11 +155,11 @@ Search first: grep for `X`, case variants, stripped variants (`createX` ↔ `X`,
 
 For `exportConstants`, the value must be a `const`. If a `let` or `function` exists under the right name, conversion to `const` is safe only if there are no reassignments — verify by grepping.
 
-When a constant entry includes `schema`, the constant must also have a matching explicit type annotation. Add or adjust the annotation only after confirming the initializer and all assignments satisfy it. Schema checks support scalar, literal-union enum, homogeneous scalar array, and inline object annotations; they do not infer initializer types or resolve named types.
+When a constant entry includes `schema`, the constant must also have a matching explicit type annotation. Add or adjust the annotation only after confirming the initializer and all assignments satisfy it. Schema checks support scalar, literal-union enum, homogeneous scalar array, and inline object annotations; they do not infer initializer types or resolve named types. For object schemas, every configured property must be declared. Names in `required` must be non-optional, while other configured names must include `?`.
 
 #### `exportTypes`
 
-Message: `Missing export type "X"`.
+Message: `Missing export type "X"` or `Type "X" ...` for schema mismatches.
 
 Search first: grep for `X`, case variants, stripped suffixes (`XConfig` ↔ `X` ↔ `XOptions` ↔ `XSettings` ↔ `XProps`), and `interface X` vs. `type X`.
 
@@ -169,6 +169,8 @@ Search first: grep for `X`, case variants, stripped suffixes (`XConfig` ↔ `X` 
   - Type exists as `interface` when `type` is expected (or vice versa) and the shape is compatible → adjust the form.
   - Type is trivially derivable (e.g., `type FooConfig = Parameters<typeof createFoo>[0]`) and the consumer pattern is obvious from siblings → write the alias.
 - **Non-trivial**: no candidate after search, and the type would require designing a new shape. Defer.
+
+When an entry includes `schema`, inspect the local type alias or interface rather than searching for a re-export. Every configured object property must exist with the exact required/optional status expressed by `required`; unconfigured properties are allowed unless `additionalProperties` is `false`. Do not replace a local schema-constrained type with a cross-file re-export, because `schema` and `from` are mutually exclusive.
 
 #### `exportFunctions`
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -96,10 +96,22 @@ All declaration predicates accept an array of bare strings or objects with a `na
 
 ### `declareTypes`
 
-Assert local type declarations. Interfaces and type aliases qualify.
+Assert local type declarations. Interfaces and type aliases qualify. An object
+entry can use `schema` to validate the local definition using the same supported
+shapes and declaration semantics as `exportTypes`.
 
 ```json
-"must": { "declareTypes": ["InternalConfig"] }
+"must": {
+  "declareTypes": [
+    {
+      "name": "InternalConfig",
+      "schema": {
+        "type": "object",
+        "properties": { "enabled": { "type": "boolean" } }
+      }
+    }
+  ]
+}
 ```
 
 ### `declareConstants`
@@ -194,7 +206,9 @@ When `from` is omitted, only the export's existence is checked. When `from` is s
 
 ### `exportTypes`
 
-Assert type-only exports. Both `export type X` and `export interface X` (when exported as a type via `export type { ... }`) match.
+Assert type-only exports. Exported type aliases and interfaces qualify. Use
+`from` to require a re-export, or use `schema` to validate a locally defined
+exported type.
 
 ```json
 "must": {
@@ -213,7 +227,32 @@ Assert type-only exports. Both `export type X` and `export interface X` (when ex
 }
 ```
 
-Same shape as `export`: bare string or `{ name, from? }`.
+```json
+"must": {
+  "exportTypes": [
+    {
+      "name": "ModuleSettings",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "model": { "type": "string" },
+          "timeout": { "type": "number" }
+        }
+      }
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | The type name. Templates allowed. |
+| `from` | string | Optional. Require a type re-export from this module specifier. |
+| `schema` | object | Optional. Validate a locally declared type definition. |
+
+`from` and `schema` are mutually exclusive. Schema validation never resolves a
+type definition from another file. The `schema` field supports the same forms
+and declaration semantics documented under [`exportConstants`](#exportconstants).
 
 ### `exportConstants`
 
@@ -263,13 +302,13 @@ The supported `schema` forms are:
 - Scalar: `{ "type": "string" }`, using `string`, `number`, `boolean`, or `null`.
 - Enum: `{ "type": "string", "enum": ["a", "b"] }`. The annotation must contain exactly the configured literal values, although their order does not matter.
 - Array: `{ "type": "array", "items": { "type": "string" } }`. Items must use a scalar schema. `T[]`, `Array<T>`, `readonly T[]`, and `ReadonlyArray<T>` annotations qualify.
-- Object: `{ "type": "object", "properties": { ... }, "required": [...], "additionalProperties": false }`. An empty property schema (`{}`) checks only that the property is permitted or required; a scalar schema also checks its type.
+- Object: `{ "type": "object", "properties": { ... }, "required": [...], "additionalProperties": false }`. Every configured property must be declared. An empty property schema (`{}`) checks its presence and optionality without constraining its type; a scalar schema also checks its type.
 
-For object schemas, `required` defaults to an empty array and `additionalProperties` defaults to `true`. Required properties must be non-optional in the TypeScript annotation.
+Object schemas describe TypeScript declaration shapes rather than ordinary JSON Schema instances. Every name in `properties` must exist in the annotation or definition. Names listed in `required` must be non-optional (`name: Type`); all other configured names must be optional (`name?: Type`). `required` defaults to an empty array. `additionalProperties` defaults to `true`, allowing unconfigured TypeScript properties; set it to `false` to reject them.
 
 This is deliberately a strict subset of JSON Schema. Unsupported keywords and shapes are rejected during configuration validation, including `integer`, `$ref`, combinators, nested object or array schemas, tuple schemas, enum array items, schema-valued `additionalProperties`, and constraints such as `minItems`.
 
-Schema checks require an explicit annotation on a locally declared constant. Inferred types, named type aliases or interfaces, tuples, index signatures, methods, computed properties, nested types, and cross-file re-exports are not resolved. Enum values and property names inside `schema` are literal data and do not expand placeholders.
+Constant schema checks require an explicit annotation on a locally declared constant. Type schema checks require a local type alias or interface definition; interfaces with `extends` are unsupported. Inferred types, named type references, tuples, intersections, index signatures, methods, computed properties, nested types, inherited properties, and cross-file re-exports are not resolved. Enum values and property names inside `schema` are literal data and do not expand placeholders.
 
 ### `exportFunctions`
 

--- a/e2e/fixtures/constant-schemas-broken/konsistent.json
+++ b/e2e/fixtures/constant-schemas-broken/konsistent.json
@@ -33,6 +33,15 @@
               "required": ["endpoint"],
               "additionalProperties": false
             }
+          },
+          {
+            "name": "optionalOptions",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {}
+              }
+            }
           }
         ]
       }

--- a/e2e/fixtures/constant-schemas-broken/src/constants.ts
+++ b/e2e/fixtures/constant-schemas-broken/src/constants.ts
@@ -6,3 +6,4 @@ export const options: { endpoint: string; retries: number } = {
   endpoint: "https://example.com",
   retries: 3,
 };
+export const optionalOptions: { metadata: unknown } = { metadata: null };

--- a/e2e/fixtures/constant-schemas/konsistent.json
+++ b/e2e/fixtures/constant-schemas/konsistent.json
@@ -34,6 +34,15 @@
               "required": ["endpoint"],
               "additionalProperties": false
             }
+          },
+          {
+            "name": "optionalOptions",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {}
+              }
+            }
           }
         ]
       }

--- a/e2e/fixtures/constant-schemas/src/constants.ts
+++ b/e2e/fixtures/constant-schemas/src/constants.ts
@@ -5,3 +5,4 @@ export const tags: readonly string[] = ["stable"];
 export const options: { endpoint: string; metadata?: unknown } = {
   endpoint: "https://example.com",
 };
+export const optionalOptions: { metadata?: unknown } = {};

--- a/e2e/fixtures/type-schemas-broken/konsistent.json
+++ b/e2e/fixtures/type-schemas-broken/konsistent.json
@@ -1,0 +1,34 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "type-schemas",
+      "paths": "src/types.ts",
+      "must": {
+        "declareTypes": [
+          {
+            "name": "InternalSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
+          }
+        ],
+        "exportTypes": [
+          {
+            "name": "ModuleSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "model": { "type": "string" },
+                "timeout": { "type": "number" }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/type-schemas-broken/src/types.ts
+++ b/e2e/fixtures/type-schemas-broken/src/types.ts
@@ -1,0 +1,8 @@
+type InternalSettings = {
+  enabled?: boolean;
+};
+
+export type ModuleSettings = {
+  model?: string;
+  reasoning?: "low" | "medium" | "high";
+};

--- a/e2e/fixtures/type-schemas/konsistent.json
+++ b/e2e/fixtures/type-schemas/konsistent.json
@@ -1,0 +1,34 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "type-schemas",
+      "paths": "src/types.ts",
+      "must": {
+        "declareTypes": [
+          {
+            "name": "InternalSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
+          }
+        ],
+        "exportTypes": [
+          {
+            "name": "ModuleSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "model": { "type": "string" },
+                "timeout": { "type": "number" }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/type-schemas/src/types.ts
+++ b/e2e/fixtures/type-schemas/src/types.ts
@@ -1,0 +1,9 @@
+type InternalSettings = {
+  enabled?: boolean;
+};
+
+export type ModuleSettings = {
+  model?: string;
+  timeout?: number;
+  reasoning?: "low" | "medium" | "high";
+};

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -78,6 +78,35 @@ describe("constant-schemas-broken fixture", () => {
       expect(error.stdout).toContain(
         'Constant "options" must not have additional property "retries"'
       );
+      expect(error.stdout).toContain(
+        'Constant "optionalOptions" property "metadata" must be optional'
+      );
+    }
+  });
+});
+
+describe("type-schemas fixture", () => {
+  const cwd = resolve(fixturesDir, "type-schemas");
+
+  it("konsistent check exits 0 for partial type schema matches", async () => {
+    await expect(runCli({ cwd })).resolves.not.toThrow();
+  });
+});
+
+describe("type-schemas-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "type-schemas-broken");
+
+  it("konsistent check exits 1 for a missing configured property", async () => {
+    try {
+      await runCli({ cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stdout: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain(
+        'Type "ModuleSettings" must define property "timeout"'
+      );
+      expect(error.stdout).toContain("type-schemas");
     }
   });
 });

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -112,6 +112,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -440,17 +574,165 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["name", "from"],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }
@@ -861,6 +1143,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -1189,17 +1605,165 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["name", "from"],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }
@@ -1691,6 +2255,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -2019,17 +2717,165 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["name", "from"],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }
@@ -2440,6 +3286,140 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "enum"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": ["type", "items"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": ["type"],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["type", "properties"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
                           "required": ["name"],
@@ -2768,17 +3748,165 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "enum"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["type"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["type", "items"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": ["type"],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["type", "properties"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": ["name"],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["name", "from"],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }

--- a/packages/convention/src/constant-schema.test.ts
+++ b/packages/convention/src/constant-schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ConstantValueSchemaV1Schema } from "./constant-schema.js";
+import {
+  ConstantValueSchemaV1Schema,
+  ExportTypeDefinitionV1Schema,
+  TypeDefinitionV1Schema,
+} from "./constant-schema.js";
 
 describe("ConstantValueSchemaV1Schema", () => {
   it.each([
@@ -50,5 +54,36 @@ describe("ConstantValueSchemaV1Schema", () => {
     { type: "string", oneOf: [{ type: "string" }] },
   ])("rejects unsupported schema %#", (schema) => {
     expect(ConstantValueSchemaV1Schema.safeParse(schema).success).toBe(false);
+  });
+});
+
+describe("type definition schemas", () => {
+  it("accepts schemas for local type definitions", () => {
+    expect(
+      TypeDefinitionV1Schema.safeParse({
+        name: "Settings",
+        schema: { type: "object", properties: {} },
+      }).success
+    ).toBe(true);
+  });
+
+  it.each([
+    { name: "Settings" },
+    { name: "Settings", from: "./settings" },
+    { name: "Settings", schema: { type: "object", properties: {} } },
+  ])("accepts exported type definition %#", (definition) => {
+    expect(ExportTypeDefinitionV1Schema.safeParse(definition).success).toBe(
+      true
+    );
+  });
+
+  it("rejects an exported type definition with both from and schema", () => {
+    expect(
+      ExportTypeDefinitionV1Schema.safeParse({
+        name: "Settings",
+        from: "./settings",
+        schema: { type: "object", properties: {} },
+      }).success
+    ).toBe(false);
   });
 });

--- a/packages/convention/src/constant-schema.ts
+++ b/packages/convention/src/constant-schema.ts
@@ -106,6 +106,19 @@ export const ExportConstantDefinitionV1Schema = z.strictObject({
   schema: ConstantValueSchemaV1Schema.optional(),
 });
 
+export const TypeDefinitionV1Schema = z.strictObject({
+  name: z.string(),
+  schema: ConstantValueSchemaV1Schema.optional(),
+});
+
+export const ExportTypeDefinitionV1Schema = z.union([
+  TypeDefinitionV1Schema,
+  z.strictObject({
+    name: z.string(),
+    from: z.string(),
+  }),
+]);
+
 export type ConstantScalarTypeV1 = z.infer<typeof ConstantScalarTypeV1Schema>;
 export type ConstantScalarSchemaV1 = z.infer<
   typeof ConstantScalarSchemaV1Schema
@@ -119,4 +132,8 @@ export type ConstantValueSchemaV1 = z.infer<typeof ConstantValueSchemaV1Schema>;
 export type ConstantDefinitionV1 = z.infer<typeof ConstantDefinitionV1Schema>;
 export type ExportConstantDefinitionV1 = z.infer<
   typeof ExportConstantDefinitionV1Schema
+>;
+export type TypeDefinitionV1 = z.infer<typeof TypeDefinitionV1Schema>;
+export type ExportTypeDefinitionV1 = z.infer<
+  typeof ExportTypeDefinitionV1Schema
 >;

--- a/packages/convention/src/generated-schema.test.ts
+++ b/packages/convention/src/generated-schema.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+import { describe, expect, it } from "vitest";
+
+const schemaPath = resolve(
+  import.meta.dirname,
+  "../reusable-convention-package.schema.json"
+);
+const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+const validate = new Ajv().compile(schema);
+
+describe("reusable-convention-package.schema.json", () => {
+  it("accepts separate schema and from exportTypes entries", () => {
+    const valid = validate({
+      conventionSpecVersion: "v1",
+      conventions: [
+        {
+          name: "settings",
+          description: "Settings exports.",
+          must: {
+            exportTypes: [
+              {
+                name: "LocalSettings",
+                schema: { type: "object", properties: {} },
+              },
+              { name: "SharedSettings", from: "./settings" },
+            ],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("rejects exportTypes entries with both from and schema", () => {
+    const valid = validate({
+      conventionSpecVersion: "v1",
+      conventions: [
+        {
+          name: "settings",
+          description: "Settings exports.",
+          must: {
+            exportTypes: [
+              {
+                name: "Settings",
+                from: "./settings",
+                schema: { type: "object", properties: {} },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(false);
+  });
+});

--- a/packages/convention/src/index.test.ts
+++ b/packages/convention/src/index.test.ts
@@ -45,7 +45,12 @@ describe("ReusableConventionV1Schema", () => {
       name: "locals",
       description: "Local declarations and import sources.",
       must: {
-        declareTypes: [{ name: "LocalType" }],
+        declareTypes: [
+          {
+            name: "LocalType",
+            schema: { type: "object", properties: {} },
+          },
+        ],
         declareConstants: ["localConstant"],
         declareFunctions: [
           {
@@ -71,6 +76,13 @@ describe("ReusableConventionV1Schema", () => {
         importTypesFromCurrentDir: true,
         importTypesFromParents: false,
         importTypesFromExternals: true,
+        exportTypes: [
+          { name: "PublicType", from: "./public" },
+          {
+            name: "LocalExport",
+            schema: { type: "object", properties: {} },
+          },
+        ],
       },
     });
     expect(result.success).toBe(true);

--- a/packages/convention/src/index.ts
+++ b/packages/convention/src/index.ts
@@ -9,6 +9,8 @@ export type {
   ConstantScalarTypeV1,
   ConstantValueSchemaV1,
   ExportConstantDefinitionV1,
+  ExportTypeDefinitionV1,
+  TypeDefinitionV1,
 } from "./constant-schema.js";
 export {
   ConstantArraySchemaV1Schema,
@@ -19,6 +21,8 @@ export {
   ConstantScalarTypeV1Schema,
   ConstantValueSchemaV1Schema,
   ExportConstantDefinitionV1Schema,
+  ExportTypeDefinitionV1Schema,
+  TypeDefinitionV1Schema,
 } from "./constant-schema.js";
 export type {
   ClassDefinitionV1,

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   ConstantDefinitionV1Schema,
   ExportConstantDefinitionV1Schema,
+  ExportTypeDefinitionV1Schema,
+  TypeDefinitionV1Schema,
 } from "./constant-schema.js";
 
 export const ExportDefinitionV1Schema = z.strictObject({
@@ -51,7 +53,7 @@ export const MustPredicatesV1Schema = z.strictObject({
   haveType: z.enum(["file", "directory"]).optional(),
   haveFiles: z.array(z.string()).optional(),
   declareTypes: z
-    .array(z.union([z.string(), DeclarationDefinitionV1Schema]))
+    .array(z.union([z.string(), TypeDefinitionV1Schema]))
     .optional(),
   declareConstants: z
     .array(z.union([z.string(), ConstantDefinitionV1Schema]))
@@ -67,7 +69,7 @@ export const MustPredicatesV1Schema = z.strictObject({
     .optional(),
   export: z.array(z.union([z.string(), ExportDefinitionV1Schema])).optional(),
   exportTypes: z
-    .array(z.union([z.string(), ExportDefinitionV1Schema]))
+    .array(z.union([z.string(), ExportTypeDefinitionV1Schema]))
     .optional(),
   exportConstants: z
     .array(z.union([z.string(), ExportConstantDefinitionV1Schema]))

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -54,7 +54,10 @@
               },
               "severity": {
                 "type": "string",
-                "enum": ["error", "warning"]
+                "enum": [
+                  "error",
+                  "warning"
+                ]
               },
               "paths": {
                 "anyOf": [
@@ -95,7 +98,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["hasFile"],
+                    "required": [
+                      "hasFile"
+                    ],
                     "additionalProperties": false
                   },
                   {
@@ -105,7 +110,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["placeholderSatisfies"],
+                    "required": [
+                      "placeholderSatisfies"
+                    ],
                     "additionalProperties": false
                   }
                 ]
@@ -127,7 +134,9 @@
                     ]
                   }
                 },
-                "required": ["files"],
+                "required": [
+                  "files"
+                ],
                 "additionalProperties": false
               },
               "must": {
@@ -135,7 +144,10 @@
                 "properties": {
                   "haveType": {
                     "type": "string",
-                    "enum": ["file", "directory"]
+                    "enum": [
+                      "file",
+                      "directory"
+                    ]
                   },
                   "haveFiles": {
                     "type": "array",
@@ -155,9 +167,160 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "type"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -211,7 +374,10 @@
                                       }
                                     }
                                   },
-                                  "required": ["type", "enum"],
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -234,11 +400,16 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["type", "items"],
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -273,7 +444,9 @@
                                                 ]
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -289,7 +462,10 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type", "properties"],
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -305,13 +481,17 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -343,7 +523,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -377,13 +559,17 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -417,7 +603,9 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -439,14 +627,18 @@
                                         "type": "boolean"
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
                               }
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -469,7 +661,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -483,17 +677,185 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "from"
+                              ],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }
@@ -549,7 +911,10 @@
                                       }
                                     }
                                   },
-                                  "required": ["type", "enum"],
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -572,11 +937,16 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["type", "items"],
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -611,7 +981,9 @@
                                                 ]
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -627,7 +999,10 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type", "properties"],
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -643,13 +1018,17 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -681,7 +1060,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -715,13 +1096,17 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -755,7 +1140,9 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -777,14 +1164,18 @@
                                         "type": "boolean"
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
                               }
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -807,7 +1198,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -843,7 +1236,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -884,7 +1279,10 @@
                 "properties": {
                   "haveType": {
                     "type": "string",
-                    "enum": ["file", "directory"]
+                    "enum": [
+                      "file",
+                      "directory"
+                    ]
                   },
                   "haveFiles": {
                     "type": "array",
@@ -904,9 +1302,160 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "schema": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    },
+                                    "enum": {
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "array"
+                                    },
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "object"
+                                    },
+                                    "properties": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      },
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "string",
+                                                  "number",
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "type"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -960,7 +1509,10 @@
                                       }
                                     }
                                   },
-                                  "required": ["type", "enum"],
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -983,11 +1535,16 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["type", "items"],
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1022,7 +1579,9 @@
                                                 ]
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -1038,7 +1597,10 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type", "properties"],
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1054,13 +1616,17 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1092,7 +1658,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1126,13 +1694,17 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1166,7 +1738,9 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1188,14 +1762,18 @@
                                         "type": "boolean"
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
                               }
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1218,7 +1796,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1232,17 +1812,185 @@
                           "type": "string"
                         },
                         {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "additionalProperties": false
                             },
-                            "from": {
-                              "type": "string"
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "from": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "from"
+                              ],
+                              "additionalProperties": false
                             }
-                          },
-                          "required": ["name"],
-                          "additionalProperties": false
+                          ]
                         }
                       ]
                     }
@@ -1298,7 +2046,10 @@
                                       }
                                     }
                                   },
-                                  "required": ["type", "enum"],
+                                  "required": [
+                                    "type",
+                                    "enum"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1321,11 +2072,16 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["type", "items"],
+                                  "required": [
+                                    "type",
+                                    "items"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1360,7 +2116,9 @@
                                                 ]
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -1376,7 +2134,10 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type", "properties"],
+                                  "required": [
+                                    "type",
+                                    "properties"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -1392,13 +2153,17 @@
                                       ]
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1430,7 +2195,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1464,13 +2231,17 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1504,7 +2275,9 @@
                                       "type": "boolean"
                                     }
                                   },
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1526,14 +2299,18 @@
                                         "type": "boolean"
                                       }
                                     },
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "additionalProperties": false
                                   }
                                 ]
                               }
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1556,7 +2333,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1592,7 +2371,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "additionalProperties": false
                         }
                       ]
@@ -1629,7 +2410,9 @@
                 "additionalProperties": false
               }
             },
-            "required": ["use"],
+            "required": [
+              "use"
+            ],
             "additionalProperties": false
           },
           {
@@ -1647,7 +2430,10 @@
                   "severity": {
                     "default": "error",
                     "type": "string",
-                    "enum": ["error", "warning"]
+                    "enum": [
+                      "error",
+                      "warning"
+                    ]
                   },
                   "excludeFiles": {
                     "type": "array",
@@ -1686,7 +2472,10 @@
                         "properties": {
                           "haveType": {
                             "type": "string",
-                            "enum": ["file", "directory"]
+                            "enum": [
+                              "file",
+                              "directory"
+                            ]
                           },
                           "haveFiles": {
                             "type": "array",
@@ -1706,9 +2495,160 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1762,7 +2702,10 @@
                                               }
                                             }
                                           },
-                                          "required": ["type", "enum"],
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -1785,11 +2728,16 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
-                                          "required": ["type", "items"],
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -1824,7 +2772,9 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -1840,7 +2790,10 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type", "properties"],
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -1856,13 +2809,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1894,7 +2851,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1928,13 +2887,17 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -1968,7 +2931,9 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -1990,14 +2955,18 @@
                                                 "type": "boolean"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2020,7 +2989,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2034,17 +3005,185 @@
                                   "type": "string"
                                 },
                                 {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "schema": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "enum": {
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                  "items": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "enum"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "array"
+                                                },
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "string",
+                                                        "number",
+                                                        "boolean",
+                                                        "null"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "items"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "object"
+                                                },
+                                                "properties": {
+                                                  "type": "object",
+                                                  "propertyNames": {
+                                                    "type": "string"
+                                                  },
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {},
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "additionalProperties": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "properties"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "additionalProperties": false
                                     },
-                                    "from": {
-                                      "type": "string"
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "from": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "from"
+                                      ],
+                                      "additionalProperties": false
                                     }
-                                  },
-                                  "required": ["name"],
-                                  "additionalProperties": false
+                                  ]
                                 }
                               ]
                             }
@@ -2100,7 +3239,10 @@
                                               }
                                             }
                                           },
-                                          "required": ["type", "enum"],
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -2123,11 +3265,16 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
-                                          "required": ["type", "items"],
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -2162,7 +3309,9 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -2178,7 +3327,10 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type", "properties"],
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -2194,13 +3346,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2232,7 +3388,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2266,13 +3424,17 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2306,7 +3468,9 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -2328,14 +3492,18 @@
                                                 "type": "boolean"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2358,7 +3526,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2394,7 +3564,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -2459,7 +3631,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["hasFile"],
+                                          "required": [
+                                            "hasFile"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -2469,7 +3643,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["placeholderSatisfies"],
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -2491,7 +3667,9 @@
                                           ]
                                         }
                                       },
-                                      "required": ["files"],
+                                      "required": [
+                                        "files"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     "excludeFiles": {
@@ -2505,7 +3683,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -2525,9 +3706,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2688,13 +4020,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2726,7 +4062,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2760,13 +4098,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2800,7 +4142,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -2822,14 +4166,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2852,7 +4200,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -2866,17 +4216,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -3039,13 +4557,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3077,7 +4599,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3111,13 +4635,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3151,7 +4679,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -3173,14 +4703,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3203,7 +4737,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3239,7 +4775,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3280,7 +4818,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -3300,9 +4841,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3463,13 +5155,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3501,7 +5197,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3535,13 +5233,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3575,7 +5277,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -3597,14 +5301,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3627,7 +5335,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3641,17 +5351,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -3814,13 +5692,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3852,7 +5734,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3886,13 +5770,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3926,7 +5814,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -3948,14 +5838,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -3978,7 +5872,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4014,7 +5910,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4051,7 +5949,9 @@
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["must"],
+                                  "required": [
+                                    "must"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -4073,7 +5973,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["hasFile"],
+                                          "required": [
+                                            "hasFile"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -4083,7 +5985,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["placeholderSatisfies"],
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -4105,7 +6009,9 @@
                                           ]
                                         }
                                       },
-                                      "required": ["files"],
+                                      "required": [
+                                        "files"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     "excludeFiles": {
@@ -4119,7 +6025,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -4139,9 +6048,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4302,13 +6362,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4340,7 +6404,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4374,13 +6440,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4414,7 +6484,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -4436,14 +6508,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4466,7 +6542,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4480,17 +6558,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -4653,13 +6899,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4691,7 +6941,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4725,13 +6977,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4765,7 +7021,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -4787,14 +7045,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4817,7 +7079,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4853,7 +7117,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -4894,7 +7160,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -4914,9 +7183,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5077,13 +7497,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5115,7 +7539,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5149,13 +7575,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5189,7 +7619,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -5211,14 +7643,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5241,7 +7677,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5255,17 +7693,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -5428,13 +8034,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5466,7 +8076,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5500,13 +8112,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5540,7 +8156,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -5562,14 +8180,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5592,7 +8214,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5628,7 +8252,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -5665,7 +8291,9 @@
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["mustNot"],
+                                  "required": [
+                                    "mustNot"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -5693,7 +8321,9 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["hasFile"],
+                                      "required": [
+                                        "hasFile"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -5703,7 +8333,9 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["placeholderSatisfies"],
+                                      "required": [
+                                        "placeholderSatisfies"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -5725,7 +8357,9 @@
                                       ]
                                     }
                                   },
-                                  "required": ["files"],
+                                  "required": [
+                                    "files"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 "excludeFiles": {
@@ -5739,7 +8373,10 @@
                                   "properties": {
                                     "haveType": {
                                       "type": "string",
-                                      "enum": ["file", "directory"]
+                                      "enum": [
+                                        "file",
+                                        "directory"
+                                      ]
                                     },
                                     "haveFiles": {
                                       "type": "array",
@@ -5759,9 +8396,160 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -5841,7 +8629,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -5920,13 +8710,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -5958,7 +8752,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -5992,13 +8788,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6032,7 +8832,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -6054,14 +8856,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6084,7 +8890,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6098,17 +8906,185 @@
                                             "type": "string"
                                           },
                                           {
-                                            "type": "object",
-                                            "properties": {
-                                              "name": {
-                                                "type": "string"
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "additionalProperties": false
                                               },
-                                              "from": {
-                                                "type": "string"
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "from": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "from"
+                                                ],
+                                                "additionalProperties": false
                                               }
-                                            },
-                                            "required": ["name"],
-                                            "additionalProperties": false
+                                            ]
                                           }
                                         ]
                                       }
@@ -6190,7 +9166,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -6269,13 +9247,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6307,7 +9289,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6341,13 +9325,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6381,7 +9369,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -6403,14 +9393,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6433,7 +9427,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6469,7 +9465,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6510,7 +9508,10 @@
                                   "properties": {
                                     "haveType": {
                                       "type": "string",
-                                      "enum": ["file", "directory"]
+                                      "enum": [
+                                        "file",
+                                        "directory"
+                                      ]
                                     },
                                     "haveFiles": {
                                       "type": "array",
@@ -6530,9 +9531,160 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6612,7 +9764,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -6691,13 +9845,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6729,7 +9887,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6763,13 +9923,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6803,7 +9967,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -6825,14 +9991,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6855,7 +10025,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -6869,17 +10041,185 @@
                                             "type": "string"
                                           },
                                           {
-                                            "type": "object",
-                                            "properties": {
-                                              "name": {
-                                                "type": "string"
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "additionalProperties": false
                                               },
-                                              "from": {
-                                                "type": "string"
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "from": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "from"
+                                                ],
+                                                "additionalProperties": false
                                               }
-                                            },
-                                            "required": ["name"],
-                                            "additionalProperties": false
+                                            ]
                                           }
                                         ]
                                       }
@@ -6961,7 +10301,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -7040,13 +10382,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7078,7 +10424,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7112,13 +10460,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7152,7 +10504,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -7174,14 +10528,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7204,7 +10562,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7240,7 +10600,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -7277,7 +10639,9 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": ["use"],
+                              "required": [
+                                "use"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7290,7 +10654,10 @@
                     "properties": {
                       "haveType": {
                         "type": "string",
-                        "enum": ["file", "directory"]
+                        "enum": [
+                          "file",
+                          "directory"
+                        ]
                       },
                       "haveFiles": {
                         "type": "array",
@@ -7310,9 +10677,160 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7366,7 +10884,10 @@
                                           }
                                         }
                                       },
-                                      "required": ["type", "enum"],
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7389,11 +10910,16 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
-                                      "required": ["type", "items"],
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7428,7 +10954,9 @@
                                                     ]
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -7444,7 +10972,10 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type", "properties"],
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7460,13 +10991,17 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7498,7 +11033,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7532,13 +11069,17 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7572,7 +11113,9 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -7594,14 +11137,18 @@
                                             "type": "boolean"
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
                                   }
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7624,7 +11171,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7638,17 +11187,185 @@
                               "type": "string"
                             },
                             {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "additionalProperties": false
                                 },
-                                "from": {
-                                  "type": "string"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "from": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "from"
+                                  ],
+                                  "additionalProperties": false
                                 }
-                              },
-                              "required": ["name"],
-                              "additionalProperties": false
+                              ]
                             }
                           ]
                         }
@@ -7704,7 +11421,10 @@
                                           }
                                         }
                                       },
-                                      "required": ["type", "enum"],
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7727,11 +11447,16 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
-                                      "required": ["type", "items"],
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7766,7 +11491,9 @@
                                                     ]
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -7782,7 +11509,10 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type", "properties"],
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -7798,13 +11528,17 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7836,7 +11570,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7870,13 +11606,17 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7910,7 +11650,9 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -7932,14 +11674,18 @@
                                             "type": "boolean"
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
                                   }
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7962,7 +11708,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -7998,7 +11746,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -8035,7 +11785,10 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["paths", "must"],
+                "required": [
+                  "paths",
+                  "must"
+                ],
                 "additionalProperties": false
               },
               {
@@ -8051,7 +11804,10 @@
                   "severity": {
                     "default": "error",
                     "type": "string",
-                    "enum": ["error", "warning"]
+                    "enum": [
+                      "error",
+                      "warning"
+                    ]
                   },
                   "excludeFiles": {
                     "type": "array",
@@ -8090,7 +11846,10 @@
                         "properties": {
                           "haveType": {
                             "type": "string",
-                            "enum": ["file", "directory"]
+                            "enum": [
+                              "file",
+                              "directory"
+                            ]
                           },
                           "haveFiles": {
                             "type": "array",
@@ -8110,9 +11869,160 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8166,7 +12076,10 @@
                                               }
                                             }
                                           },
-                                          "required": ["type", "enum"],
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8189,11 +12102,16 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
-                                          "required": ["type", "items"],
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8228,7 +12146,9 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -8244,7 +12164,10 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type", "properties"],
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8260,13 +12183,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8298,7 +12225,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8332,13 +12261,17 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8372,7 +12305,9 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -8394,14 +12329,18 @@
                                                 "type": "boolean"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8424,7 +12363,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8438,17 +12379,185 @@
                                   "type": "string"
                                 },
                                 {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "schema": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                },
+                                                "enum": {
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                  "items": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "enum"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "array"
+                                                },
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "string",
+                                                        "number",
+                                                        "boolean",
+                                                        "null"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "items"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "const": "object"
+                                                },
+                                                "properties": {
+                                                  "type": "object",
+                                                  "propertyNames": {
+                                                    "type": "string"
+                                                  },
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {},
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "additionalProperties": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "properties"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "additionalProperties": false
                                     },
-                                    "from": {
-                                      "type": "string"
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "from": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "from"
+                                      ],
+                                      "additionalProperties": false
                                     }
-                                  },
-                                  "required": ["name"],
-                                  "additionalProperties": false
+                                  ]
                                 }
                               ]
                             }
@@ -8504,7 +12613,10 @@
                                               }
                                             }
                                           },
-                                          "required": ["type", "enum"],
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8527,11 +12639,16 @@
                                                   ]
                                                 }
                                               },
-                                              "required": ["type"],
+                                              "required": [
+                                                "type"
+                                              ],
                                               "additionalProperties": false
                                             }
                                           },
-                                          "required": ["type", "items"],
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8566,7 +12683,9 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -8582,7 +12701,10 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type", "properties"],
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8598,13 +12720,17 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8636,7 +12762,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8670,13 +12798,17 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8710,7 +12842,9 @@
                                               "type": "boolean"
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -8732,14 +12866,18 @@
                                                 "type": "boolean"
                                               }
                                             },
-                                            "required": ["type"],
+                                            "required": [
+                                              "type"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8762,7 +12900,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8798,7 +12938,9 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -8863,7 +13005,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["hasFile"],
+                                          "required": [
+                                            "hasFile"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -8873,7 +13017,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["placeholderSatisfies"],
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -8895,7 +13041,9 @@
                                           ]
                                         }
                                       },
-                                      "required": ["files"],
+                                      "required": [
+                                        "files"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     "excludeFiles": {
@@ -8909,7 +13057,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -8929,9 +13080,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9092,13 +13394,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9130,7 +13436,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9164,13 +13472,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9204,7 +13516,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -9226,14 +13540,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9256,7 +13574,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9270,17 +13590,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -9443,13 +13931,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9481,7 +13973,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9515,13 +14009,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9555,7 +14053,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -9577,14 +14077,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9607,7 +14111,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9643,7 +14149,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9684,7 +14192,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -9704,9 +14215,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9867,13 +14529,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9905,7 +14571,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9939,13 +14607,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -9979,7 +14651,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -10001,14 +14675,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10031,7 +14709,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10045,17 +14725,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -10218,13 +15066,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10256,7 +15108,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10290,13 +15144,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10330,7 +15188,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -10352,14 +15212,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10382,7 +15246,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10418,7 +15284,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10455,7 +15323,9 @@
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["must"],
+                                  "required": [
+                                    "must"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 {
@@ -10477,7 +15347,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["hasFile"],
+                                          "required": [
+                                            "hasFile"
+                                          ],
                                           "additionalProperties": false
                                         },
                                         {
@@ -10487,7 +15359,9 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["placeholderSatisfies"],
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       ]
@@ -10509,7 +15383,9 @@
                                           ]
                                         }
                                       },
-                                      "required": ["files"],
+                                      "required": [
+                                        "files"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     "excludeFiles": {
@@ -10523,7 +15399,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -10543,9 +15422,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10706,13 +15736,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10744,7 +15778,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10778,13 +15814,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10818,7 +15858,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -10840,14 +15882,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10870,7 +15916,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -10884,17 +15932,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -11057,13 +16273,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11095,7 +16315,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11129,13 +16351,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11169,7 +16395,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -11191,14 +16419,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11221,7 +16453,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11257,7 +16491,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11298,7 +16534,10 @@
                                       "properties": {
                                         "haveType": {
                                           "type": "string",
-                                          "enum": ["file", "directory"]
+                                          "enum": [
+                                            "file",
+                                            "directory"
+                                          ]
                                         },
                                         "haveFiles": {
                                           "type": "array",
@@ -11318,9 +16557,160 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11481,13 +16871,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11519,7 +16913,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11553,13 +16949,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11593,7 +16993,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -11615,14 +17017,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11645,7 +17051,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11659,17 +17067,185 @@
                                                 "type": "string"
                                               },
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "schema": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              },
+                                                              "enum": {
+                                                                "minItems": 1,
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    },
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "enum"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "array"
+                                                              },
+                                                              "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                  "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                      "string",
+                                                                      "number",
+                                                                      "boolean",
+                                                                      "null"
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "type"
+                                                                ],
+                                                                "additionalProperties": false
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "items"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "const": "object"
+                                                              },
+                                                              "properties": {
+                                                                "type": "object",
+                                                                "propertyNames": {
+                                                                  "type": "string"
+                                                                },
+                                                                "additionalProperties": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {},
+                                                                      "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "type": {
+                                                                          "type": "string",
+                                                                          "enum": [
+                                                                            "string",
+                                                                            "number",
+                                                                            "boolean",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "type"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "additionalProperties": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type",
+                                                              "properties"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name"
+                                                    ],
+                                                    "additionalProperties": false
                                                   },
-                                                  "from": {
-                                                    "type": "string"
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "from": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "from"
+                                                    ],
+                                                    "additionalProperties": false
                                                   }
-                                                },
-                                                "required": ["name"],
-                                                "additionalProperties": false
+                                                ]
                                               }
                                             ]
                                           }
@@ -11832,13 +17408,17 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11870,7 +17450,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11904,13 +17486,17 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11944,7 +17530,9 @@
                                                             "type": "boolean"
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     ]
@@ -11966,14 +17554,18 @@
                                                               "type": "boolean"
                                                             }
                                                           },
-                                                          "required": ["type"],
+                                                          "required": [
+                                                            "type"
+                                                          ],
                                                           "additionalProperties": false
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -11996,7 +17588,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -12032,7 +17626,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["name"],
+                                                "required": [
+                                                  "name"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -12069,7 +17665,9 @@
                                       "additionalProperties": false
                                     }
                                   },
-                                  "required": ["mustNot"],
+                                  "required": [
+                                    "mustNot"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
@@ -12097,7 +17695,9 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["hasFile"],
+                                      "required": [
+                                        "hasFile"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -12107,7 +17707,9 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["placeholderSatisfies"],
+                                      "required": [
+                                        "placeholderSatisfies"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -12129,7 +17731,9 @@
                                       ]
                                     }
                                   },
-                                  "required": ["files"],
+                                  "required": [
+                                    "files"
+                                  ],
                                   "additionalProperties": false
                                 },
                                 "excludeFiles": {
@@ -12143,7 +17747,10 @@
                                   "properties": {
                                     "haveType": {
                                       "type": "string",
-                                      "enum": ["file", "directory"]
+                                      "enum": [
+                                        "file",
+                                        "directory"
+                                      ]
                                     },
                                     "haveFiles": {
                                       "type": "array",
@@ -12163,9 +17770,160 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12245,7 +18003,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -12324,13 +18084,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12362,7 +18126,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12396,13 +18162,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12436,7 +18206,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -12458,14 +18230,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12488,7 +18264,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12502,17 +18280,185 @@
                                             "type": "string"
                                           },
                                           {
-                                            "type": "object",
-                                            "properties": {
-                                              "name": {
-                                                "type": "string"
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "additionalProperties": false
                                               },
-                                              "from": {
-                                                "type": "string"
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "from": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "from"
+                                                ],
+                                                "additionalProperties": false
                                               }
-                                            },
-                                            "required": ["name"],
-                                            "additionalProperties": false
+                                            ]
                                           }
                                         ]
                                       }
@@ -12594,7 +18540,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -12673,13 +18621,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12711,7 +18663,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12745,13 +18699,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12785,7 +18743,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -12807,14 +18767,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12837,7 +18801,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12873,7 +18839,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -12914,7 +18882,10 @@
                                   "properties": {
                                     "haveType": {
                                       "type": "string",
-                                      "enum": ["file", "directory"]
+                                      "enum": [
+                                        "file",
+                                        "directory"
+                                      ]
                                     },
                                     "haveFiles": {
                                       "type": "array",
@@ -12934,9 +18905,160 @@
                                             "properties": {
                                               "name": {
                                                 "type": "string"
+                                              },
+                                              "schema": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      },
+                                                      "enum": {
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "number"
+                                                            },
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "enum"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "array"
+                                                      },
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "items"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "const": "object"
+                                                      },
+                                                      "properties": {
+                                                        "type": "object",
+                                                        "propertyNames": {
+                                                          "type": "string"
+                                                        },
+                                                        "additionalProperties": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {},
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "type": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "string",
+                                                                    "number",
+                                                                    "boolean",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "type"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "required": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type",
+                                                      "properties"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13016,7 +19138,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -13095,13 +19219,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13133,7 +19261,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13167,13 +19297,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13207,7 +19341,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -13229,14 +19365,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13259,7 +19399,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13273,17 +19415,185 @@
                                             "type": "string"
                                           },
                                           {
-                                            "type": "object",
-                                            "properties": {
-                                              "name": {
-                                                "type": "string"
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "schema": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          },
+                                                          "enum": {
+                                                            "minItems": 1,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                },
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "enum"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                          },
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "string",
+                                                                  "number",
+                                                                  "boolean",
+                                                                  "null"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "type"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "items"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                          },
+                                                          "properties": {
+                                                            "type": "object",
+                                                            "propertyNames": {
+                                                              "type": "string"
+                                                            },
+                                                            "additionalProperties": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {},
+                                                                  "additionalProperties": false
+                                                                },
+                                                                {
+                                                                  "type": "object",
+                                                                  "properties": {
+                                                                    "type": {
+                                                                      "type": "string",
+                                                                      "enum": [
+                                                                        "string",
+                                                                        "number",
+                                                                        "boolean",
+                                                                        "null"
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "type"
+                                                                  ],
+                                                                  "additionalProperties": false
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": {
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "additionalProperties": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type",
+                                                          "properties"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      },
+                                                      {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                              "string",
+                                                              "number",
+                                                              "boolean",
+                                                              "null"
+                                                            ]
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "type"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "additionalProperties": false
                                               },
-                                              "from": {
-                                                "type": "string"
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "from": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "from"
+                                                ],
+                                                "additionalProperties": false
                                               }
-                                            },
-                                            "required": ["name"],
-                                            "additionalProperties": false
+                                            ]
                                           }
                                         ]
                                       }
@@ -13365,7 +19675,9 @@
                                                             ]
                                                           }
                                                         },
-                                                        "required": ["type"],
+                                                        "required": [
+                                                          "type"
+                                                        ],
                                                         "additionalProperties": false
                                                       }
                                                     },
@@ -13444,13 +19756,17 @@
                                                         ]
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13482,7 +19798,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13516,13 +19834,17 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13556,7 +19878,9 @@
                                                         "type": "boolean"
                                                       }
                                                     },
-                                                    "required": ["type"],
+                                                    "required": [
+                                                      "type"
+                                                    ],
                                                     "additionalProperties": false
                                                   }
                                                 ]
@@ -13578,14 +19902,18 @@
                                                           "type": "boolean"
                                                         }
                                                       },
-                                                      "required": ["type"],
+                                                      "required": [
+                                                        "type"
+                                                      ],
                                                       "additionalProperties": false
                                                     }
                                                   ]
                                                 }
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13608,7 +19936,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13644,7 +19974,9 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["name"],
+                                            "required": [
+                                              "name"
+                                            ],
                                             "additionalProperties": false
                                           }
                                         ]
@@ -13681,7 +20013,9 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": ["use"],
+                              "required": [
+                                "use"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -13694,7 +20028,10 @@
                     "properties": {
                       "haveType": {
                         "type": "string",
-                        "enum": ["file", "directory"]
+                        "enum": [
+                          "file",
+                          "directory"
+                        ]
                       },
                       "haveFiles": {
                         "type": "array",
@@ -13714,9 +20051,160 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "schema": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "enum": {
+                                          "minItems": 1,
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "array"
+                                        },
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "object"
+                                        },
+                                        "properties": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {},
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "string",
+                                                      "number",
+                                                      "boolean",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -13770,7 +20258,10 @@
                                           }
                                         }
                                       },
-                                      "required": ["type", "enum"],
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -13793,11 +20284,16 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
-                                      "required": ["type", "items"],
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -13832,7 +20328,9 @@
                                                     ]
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -13848,7 +20346,10 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type", "properties"],
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -13864,13 +20365,17 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -13902,7 +20407,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -13936,13 +20443,17 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -13976,7 +20487,9 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -13998,14 +20511,18 @@
                                             "type": "boolean"
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
                                   }
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14028,7 +20545,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14042,17 +20561,185 @@
                               "type": "string"
                             },
                             {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            },
+                                            "enum": {
+                                              "minItems": 1,
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "enum"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "array"
+                                            },
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "boolean",
+                                                    "null"
+                                                  ]
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "items"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "const": "object"
+                                            },
+                                            "properties": {
+                                              "type": "object",
+                                              "propertyNames": {
+                                                "type": "string"
+                                              },
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": false
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "string",
+                                                          "number",
+                                                          "boolean",
+                                                          "null"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "type"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "type",
+                                            "properties"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "string",
+                                                "number",
+                                                "boolean",
+                                                "null"
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "type"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "additionalProperties": false
                                 },
-                                "from": {
-                                  "type": "string"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "from": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "from"
+                                  ],
+                                  "additionalProperties": false
                                 }
-                              },
-                              "required": ["name"],
-                              "additionalProperties": false
+                              ]
                             }
                           ]
                         }
@@ -14108,7 +20795,10 @@
                                           }
                                         }
                                       },
-                                      "required": ["type", "enum"],
+                                      "required": [
+                                        "type",
+                                        "enum"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -14131,11 +20821,16 @@
                                               ]
                                             }
                                           },
-                                          "required": ["type"],
+                                          "required": [
+                                            "type"
+                                          ],
                                           "additionalProperties": false
                                         }
                                       },
-                                      "required": ["type", "items"],
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -14170,7 +20865,9 @@
                                                     ]
                                                   }
                                                 },
-                                                "required": ["type"],
+                                                "required": [
+                                                  "type"
+                                                ],
                                                 "additionalProperties": false
                                               }
                                             ]
@@ -14186,7 +20883,10 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type", "properties"],
+                                      "required": [
+                                        "type",
+                                        "properties"
+                                      ],
                                       "additionalProperties": false
                                     },
                                     {
@@ -14202,13 +20902,17 @@
                                           ]
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14240,7 +20944,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14274,13 +20980,17 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14314,7 +21024,9 @@
                                           "type": "boolean"
                                         }
                                       },
-                                      "required": ["type"],
+                                      "required": [
+                                        "type"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -14336,14 +21048,18 @@
                                             "type": "boolean"
                                           }
                                         },
-                                        "required": ["type"],
+                                        "required": [
+                                          "type"
+                                        ],
                                         "additionalProperties": false
                                       }
                                     ]
                                   }
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14366,7 +21082,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14402,7 +21120,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "additionalProperties": false
                             }
                           ]
@@ -14439,7 +21159,10 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["paths", "mustNot"],
+                "required": [
+                  "paths",
+                  "mustNot"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -14448,7 +21171,10 @@
       }
     }
   },
-  "required": ["version", "conventions"],
+  "required": [
+    "version",
+    "conventions"
+  ],
   "additionalProperties": false,
   "$id": "https://unpkg.com/konsistent/konsistent.schema.json"
 }

--- a/packages/konsistent/scripts/generate-schema.test.ts
+++ b/packages/konsistent/scripts/generate-schema.test.ts
@@ -85,4 +85,25 @@ describe("konsistent.schema.json", () => {
     const valid = validate(config);
     expect(valid).toBe(false);
   });
+
+  it("rejects exportTypes entries with both from and schema", () => {
+    const valid = validate({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/settings.ts",
+          must: {
+            exportTypes: [
+              {
+                name: "Settings",
+                from: "./settings",
+                schema: { type: "object", properties: {} },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(false);
+  });
 });

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -95,7 +95,12 @@ describe("ConfigV1Schema", () => {
         {
           paths: "src/*.ts",
           must: {
-            declareTypes: [{ name: "LocalType" }],
+            declareTypes: [
+              {
+                name: "LocalType",
+                schema: { type: "object", properties: {} },
+              },
+            ],
             declareConstants: ["localConstant"],
             declareFunctions: [
               {
@@ -118,6 +123,27 @@ describe("ConfigV1Schema", () => {
       ],
     });
     expect(result.success).toBe(true);
+  });
+
+  it("rejects exportTypes entries with both from and schema", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            exportTypes: [
+              {
+                name: "Settings",
+                from: "./settings",
+                schema: { type: "object", properties: {} },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
   });
 
   it("accepts conventions with declaration order and import source predicates", () => {

--- a/packages/konsistent/src/config/schema.ts
+++ b/packages/konsistent/src/config/schema.ts
@@ -16,6 +16,7 @@ export type {
   DeclarationDefinitionV1,
   ExportConstantDefinitionV1,
   ExportDefinitionV1,
+  ExportTypeDefinitionV1,
   FunctionDefinitionV1,
   ImportDefinitionV1,
   InterfaceDefinitionV1,
@@ -23,6 +24,7 @@ export type {
   MustPredicatesV1,
   ReusableConventionsPackageV1,
   ReusableConventionV1,
+  TypeDefinitionV1,
 } from "@konsistent/convention";
 export {
   ClassDefinitionV1Schema,
@@ -36,6 +38,7 @@ export {
   DeclarationDefinitionV1Schema,
   ExportConstantDefinitionV1Schema,
   ExportDefinitionV1Schema,
+  ExportTypeDefinitionV1Schema,
   FunctionDefinitionV1Schema,
   ImportDefinitionV1Schema,
   InterfaceDefinitionV1Schema,
@@ -43,6 +46,7 @@ export {
   MustPredicatesV1Schema,
   ReusableConventionsPackageV1Schema,
   ReusableConventionV1Schema,
+  TypeDefinitionV1Schema,
 } from "@konsistent/convention";
 
 const PlaceholdersMapSchema = z.record(

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -251,6 +251,72 @@ describe("run", () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it("forbids an exported type matching a mustNot schema", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            exportTypes: [
+              {
+                name: "DebugSettings",
+                schema: {
+                  type: "object",
+                  properties: { enabled: { type: "boolean" } },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        ["src/module.ts", "export type DebugSettings = { enabled?: boolean };"],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].predicateName).toBe("mustNot.exportTypes");
+    expect(diagnostics[0].message).toBe(
+      'Forbidden type export "DebugSettings"'
+    );
+  });
+
+  it("allows a mustNot exported type with different optionality", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            exportTypes: [
+              {
+                name: "DebugSettings",
+                schema: {
+                  type: "object",
+                  properties: { enabled: { type: "boolean" } },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        ["src/module.ts", "export type DebugSettings = { enabled: boolean };"],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toEqual([]);
+  });
+
   it("returns no diagnostics when mustNot importFrom does not match a subpath", async () => {
     const config: ConfigV1 = {
       version: "v1",

--- a/packages/konsistent/src/typescript/constant-type-schema.test.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.test.ts
@@ -1,6 +1,9 @@
 import type { ConstantValueSchemaV1 } from "@konsistent/convention";
 import { describe, expect, it } from "vitest";
-import { matchConstantTypeSchema } from "./constant-type-schema.js";
+import {
+  matchConstantTypeSchema,
+  matchTypeDefinitionSchema,
+} from "./constant-type-schema.js";
 import { parseFileStructure } from "./parser.js";
 
 function getTypeInfo(opts: { type: string }) {
@@ -16,6 +19,21 @@ function matches(opts: {
     actual: getTypeInfo({ type: opts.type }),
     schema: opts.schema,
   }).matches;
+}
+
+function matchDefinition(opts: {
+  name: string;
+  schema: ConstantValueSchemaV1;
+  source: string;
+}) {
+  const fileStructure = parseFileStructure({ source: opts.source });
+  const definition =
+    fileStructure.typeAliases.find((item) => item.name === opts.name) ??
+    fileStructure.interfaces.find((item) => item.name === opts.name);
+  return matchTypeDefinitionSchema({
+    actual: definition?.typeInfo,
+    schema: opts.schema,
+  });
 }
 
 describe("constant type schemas", () => {
@@ -136,6 +154,38 @@ describe("constant type schemas", () => {
     );
   });
 
+  it("requires configured non-required properties to exist and be optional", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { name: { type: "string" as const } },
+    };
+    expect(matches({ type: "{ name?: string }", schema })).toBe(true);
+    expect(matches({ type: "{}", schema })).toBe(false);
+    expect(matches({ type: "{ name: string }", schema })).toBe(false);
+  });
+
+  it("reports exact object property declaration mismatches", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { name: { type: "string" as const } },
+    };
+    expect(
+      matchConstantTypeSchema({ actual: getTypeInfo({ type: "{}" }), schema })
+    ).toEqual({
+      matches: false,
+      reason: 'must define property "name"',
+    });
+    expect(
+      matchConstantTypeSchema({
+        actual: getTypeInfo({ type: "{ name: string }" }),
+        schema,
+      })
+    ).toEqual({
+      matches: false,
+      reason: 'property "name" must be optional',
+    });
+  });
+
   it("allows additional properties by default", () => {
     expect(
       matches({
@@ -168,6 +218,88 @@ describe("constant type schemas", () => {
     expect(result).toEqual({
       matches: false,
       reason: "must have an explicit type annotation",
+    });
+  });
+});
+
+describe("type definition schemas", () => {
+  const partialSettingsSchema = {
+    type: "object" as const,
+    properties: {
+      model: { type: "string" as const },
+      timeout: { type: "number" as const },
+    },
+  };
+
+  it("partially matches configured optional type alias properties", () => {
+    const result = matchDefinition({
+      name: "ModuleSettings",
+      schema: partialSettingsSchema,
+      source: `
+        type ModuleSettings = {
+          model?: string;
+          timeout?: number;
+          reasoning?: "low" | "medium" | "high";
+        };
+      `,
+    });
+    expect(result).toEqual({ matches: true });
+  });
+
+  it("rejects a type alias missing a configured optional property", () => {
+    const result = matchDefinition({
+      name: "ModuleSettings",
+      schema: partialSettingsSchema,
+      source: `
+        type ModuleSettings = {
+          model?: string;
+          reasoning?: "low" | "medium" | "high";
+        };
+      `,
+    });
+    expect(result).toEqual({
+      matches: false,
+      reason: 'must define property "timeout"',
+    });
+  });
+
+  it("matches directly declared interface properties", () => {
+    const result = matchDefinition({
+      name: "Settings",
+      schema: {
+        type: "object",
+        properties: { enabled: { type: "boolean" } },
+      },
+      source: "interface Settings { enabled?: boolean }",
+    });
+    expect(result).toEqual({ matches: true });
+  });
+
+  it.each([
+    "type Settings = BaseSettings;",
+    "interface Settings extends BaseSettings { enabled?: boolean }",
+    "interface Settings { run(): void }",
+  ])("rejects unsupported type definition %s", (source) => {
+    const result = matchDefinition({
+      name: "Settings",
+      schema: { type: "object", properties: {} },
+      source,
+    });
+    expect(result).toEqual({
+      matches: false,
+      reason: "uses an unsupported type definition",
+    });
+  });
+
+  it("requires a local type definition", () => {
+    expect(
+      matchTypeDefinitionSchema({
+        actual: undefined,
+        schema: { type: "object", properties: {} },
+      })
+    ).toEqual({
+      matches: false,
+      reason: "must have a local type definition",
     });
   });
 });

--- a/packages/konsistent/src/typescript/constant-type-schema.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.ts
@@ -44,6 +44,8 @@ export type ConstantTypeInfo =
   | ConstantObjectTypeInfo
   | UnsupportedConstantTypeInfo;
 
+export type TypeShapeInfo = ConstantTypeInfo;
+
 export interface ConstantSchemaMatchResult {
   matches: boolean;
   reason?: string;
@@ -162,13 +164,14 @@ function getPropertyName(name: ts.PropertyName): string | undefined {
   return;
 }
 
-function parseObjectType(
-  node: ts.TypeLiteralNode
-): ConstantObjectTypeInfo | undefined {
+function parseObjectType(opts: {
+  members: ts.NodeArray<ts.TypeElement>;
+}): ConstantObjectTypeInfo | undefined {
+  const { members } = opts;
   const properties: ConstantObjectPropertyTypeInfo[] = [];
   const names = new Set<string>();
 
-  for (const member of node.members) {
+  for (const member of members) {
     if (!(ts.isPropertySignature(member) && member.name)) {
       return;
     }
@@ -188,7 +191,7 @@ function parseObjectType(
   return { kind: "object", properties };
 }
 
-export function parseConstantTypeAnnotation(opts: {
+export function parseTypeShape(opts: {
   node: ts.TypeNode | undefined;
 }): ConstantTypeInfo | undefined {
   const { node } = opts;
@@ -212,10 +215,22 @@ export function parseConstantTypeAnnotation(opts: {
   }
 
   if (ts.isTypeLiteralNode(node)) {
-    return parseObjectType(node) ?? { kind: "unsupported" };
+    return (
+      parseObjectType({ members: node.members }) ?? { kind: "unsupported" }
+    );
   }
 
   return { kind: "unsupported" };
+}
+
+export function parseInterfaceTypeShape(opts: {
+  node: ts.InterfaceDeclaration;
+}): ConstantTypeInfo {
+  const { node } = opts;
+  if (node.heritageClauses?.length) {
+    return { kind: "unsupported" };
+  }
+  return parseObjectType({ members: node.members }) ?? { kind: "unsupported" };
 }
 
 function scalarValueKey(value: ConstantScalarValue): string {
@@ -269,29 +284,34 @@ function matchObjectSchema(opts: {
   const actualProperties = new Map(
     actual.properties.map((property) => [property.name, property])
   );
+  const requiredProperties = new Set(schema.required ?? []);
 
-  for (const name of schema.required ?? []) {
+  for (const [name, propertySchema] of Object.entries(schema.properties)) {
     const property = actualProperties.get(name);
     if (!property) {
       return {
         matches: false,
-        reason: `must have required property "${name}"`,
+        reason: requiredProperties.has(name)
+          ? `must have required property "${name}"`
+          : `must define property "${name}"`,
       };
     }
-    if (property.optional) {
+    if (requiredProperties.has(name) && property.optional) {
       return {
         matches: false,
         reason: `property "${name}" must not be optional`,
       };
     }
-  }
-
-  for (const [name, propertySchema] of Object.entries(schema.properties)) {
-    const property = actualProperties.get(name);
-    if (!(property && Object.hasOwn(propertySchema, "type"))) {
-      continue;
+    if (!(requiredProperties.has(name) || property.optional)) {
+      return {
+        matches: false,
+        reason: `property "${name}" must be optional`,
+      };
     }
-    if (property.scalarType !== propertySchema.type) {
+    if (
+      Object.hasOwn(propertySchema, "type") &&
+      property.scalarType !== propertySchema.type
+    ) {
       return {
         matches: false,
         reason: `property "${name}" must be of type "${propertySchema.type}"`,
@@ -314,16 +334,18 @@ function matchObjectSchema(opts: {
   return { matches: true };
 }
 
-export function matchConstantTypeSchema(opts: {
+function matchTypeSchema(opts: {
   actual: ConstantTypeInfo | undefined;
+  missingReason: string;
   schema: ConstantValueSchemaV1;
+  unsupportedReason: string;
 }): ConstantSchemaMatchResult {
-  const { actual, schema } = opts;
+  const { actual, missingReason, schema, unsupportedReason } = opts;
   if (!actual) {
-    return { matches: false, reason: "must have an explicit type annotation" };
+    return { matches: false, reason: missingReason };
   }
   if (actual.kind === "unsupported") {
-    return { matches: false, reason: "uses an unsupported type annotation" };
+    return { matches: false, reason: unsupportedReason };
   }
   if (Object.hasOwn(schema, "enum")) {
     return matchEnumSchema({ actual, schema });
@@ -344,4 +366,26 @@ export function matchConstantTypeSchema(opts: {
     return { matches: false, reason: `must be of type "${schema.type}"` };
   }
   return { matches: true };
+}
+
+export function matchConstantTypeSchema(opts: {
+  actual: ConstantTypeInfo | undefined;
+  schema: ConstantValueSchemaV1;
+}): ConstantSchemaMatchResult {
+  return matchTypeSchema({
+    ...opts,
+    missingReason: "must have an explicit type annotation",
+    unsupportedReason: "uses an unsupported type annotation",
+  });
+}
+
+export function matchTypeDefinitionSchema(opts: {
+  actual: ConstantTypeInfo | undefined;
+  schema: ConstantValueSchemaV1;
+}): ConstantSchemaMatchResult {
+  return matchTypeSchema({
+    ...opts,
+    missingReason: "must have a local type definition",
+    unsupportedReason: "uses an unsupported type definition",
+  });
 }

--- a/packages/konsistent/src/typescript/parser.test.ts
+++ b/packages/konsistent/src/typescript/parser.test.ts
@@ -397,6 +397,10 @@ describe("parseFileStructure", () => {
       expect(result.interfaces[0]).toMatchObject({
         name: "Foo",
         extends: [],
+        typeInfo: {
+          kind: "object",
+          properties: [{ name: "bar", optional: false, scalarType: "string" }],
+        },
       });
     });
 
@@ -411,6 +415,7 @@ describe("parseFileStructure", () => {
           { name: "Bar", typeArguments: [] },
           { name: "Baz", typeArguments: [] },
         ],
+        typeInfo: { kind: "unsupported" },
       });
     });
 
@@ -603,7 +608,26 @@ describe("parseFileStructure", () => {
         source: "type ID = string | number;",
       });
       expect(result.typeAliases).toHaveLength(1);
-      expect(result.typeAliases[0]).toMatchObject({ name: "ID" });
+      expect(result.typeAliases[0]).toMatchObject({
+        name: "ID",
+        typeInfo: { kind: "unsupported" },
+      });
+    });
+
+    it("extracts type alias shapes", () => {
+      const result = parseFileStructure({
+        source: "type Settings = { model?: string; timeout: number };",
+      });
+      expect(result.typeAliases[0]).toMatchObject({
+        name: "Settings",
+        typeInfo: {
+          kind: "object",
+          properties: [
+            { name: "model", optional: true, scalarType: "string" },
+            { name: "timeout", optional: false, scalarType: "number" },
+          ],
+        },
+      });
     });
   });
 

--- a/packages/konsistent/src/typescript/parser.ts
+++ b/packages/konsistent/src/typescript/parser.ts
@@ -1,5 +1,8 @@
 import ts from "typescript";
-import { parseConstantTypeAnnotation } from "./constant-type-schema.js";
+import {
+  parseInterfaceTypeShape,
+  parseTypeShape,
+} from "./constant-type-schema.js";
 import type {
   ClassInfo,
   ConstantInfo,
@@ -419,7 +422,7 @@ function processVariableStatement(opts: {
       const pos = getPosition({ sourceFile, node });
       collector.constants.push({
         name: decl.name.getText(sourceFile),
-        typeInfo: parseConstantTypeAnnotation({ node: decl.type }),
+        typeInfo: parseTypeShape({ node: decl.type }),
         typeName: extractTypeAnnotation(decl.type),
         pos,
       });
@@ -442,6 +445,7 @@ function processDeclaration(opts: {
         clauses: node.heritageClauses,
         kind: ts.SyntaxKind.ExtendsKeyword,
       }),
+      typeInfo: parseInterfaceTypeShape({ node }),
       pos,
     });
   }
@@ -482,6 +486,7 @@ function processDeclaration(opts: {
     const pos = getPosition({ sourceFile, node });
     collector.typeAliases.push({
       name: node.name.getText(sourceFile),
+      typeInfo: parseTypeShape({ node: node.type }),
       pos,
     });
   }

--- a/packages/konsistent/src/typescript/predicates/declaration-utils.ts
+++ b/packages/konsistent/src/typescript/predicates/declaration-utils.ts
@@ -34,6 +34,19 @@ export function findDeclarationSymbol(opts: {
   );
 }
 
+export function findTypeDefinition(opts: {
+  fileStructure: FileStructure;
+  name: string;
+}) {
+  const { fileStructure, name } = opts;
+  return (
+    fileStructure.typeAliases.find((typeAlias) => typeAlias.name === name) ??
+    fileStructure.interfaces.find(
+      (interfaceInfo) => interfaceInfo.name === name
+    )
+  );
+}
+
 export function isDeclarationSymbolExported(opts: {
   fileStructure: FileStructure;
   symbol: DeclarationSymbolInfo;

--- a/packages/konsistent/src/typescript/predicates/declare-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-types.test.ts
@@ -53,4 +53,58 @@ describe("checkDeclareTypes", () => {
     );
     expect(result[0].predicateName).toBe("declareTypes");
   });
+
+  it("validates schemas for local type aliases and interfaces", () => {
+    const result = checkDeclareTypes({
+      expected: [
+        {
+          name: "Settings",
+          schema: {
+            type: "object",
+            properties: { model: { type: "string" } },
+          },
+        },
+        {
+          name: "Options",
+          schema: {
+            type: "object",
+            properties: { enabled: { type: "boolean" } },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: [
+          "type Settings = { model?: string; extra?: number };",
+          "interface Options { enabled?: boolean }",
+        ].join("\n"),
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("reports schema mismatches for local type definitions", () => {
+    const result = checkDeclareTypes({
+      expected: [
+        {
+          name: "Settings",
+          schema: {
+            type: "object",
+            properties: { timeout: { type: "number" } },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "type Settings = { model?: string };",
+      }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      message: 'Type "Settings" must define property "timeout"',
+      predicateName: "declareTypes",
+      line: 1,
+      column: 1,
+    });
+  });
 });

--- a/packages/konsistent/src/typescript/predicates/declare-types.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-types.ts
@@ -1,17 +1,21 @@
+import type { TypeDefinitionV1 } from "@konsistent/convention";
 import type { PredicateContext } from "../../core/context.js";
 import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
+import { createDiagnostic } from "../../core/diagnostics.js";
+import { matchTypeDefinitionSchema } from "../constant-type-schema.js";
 import type { FileStructure } from "../types.js";
 import {
   createExportedDeclarationDiagnostic,
   createMissingDeclarationDiagnostic,
   type DeclarationCheckContext,
   findDeclarationSymbol,
+  findTypeDefinition,
   isDeclarationSymbolExported,
   resolveDefinitionName,
 } from "./declaration-utils.js";
 
 export function checkDeclareTypes(opts: {
-  expected: (string | { name: string })[];
+  expected: (string | TypeDefinitionV1)[];
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -27,6 +31,7 @@ export function checkDeclareTypes(opts: {
   };
 
   for (const entry of expected) {
+    const definition = typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = resolveDefinitionName({ entry, context });
     const symbol = findDeclarationSymbol({
       fileStructure,
@@ -53,6 +58,31 @@ export function checkDeclareTypes(opts: {
           symbol,
         })
       );
+      continue;
+    }
+
+    if (definition.schema) {
+      const typeDefinition = findTypeDefinition({
+        fileStructure,
+        name: resolvedName,
+      });
+      const result = matchTypeDefinitionSchema({
+        actual: typeDefinition?.typeInfo,
+        schema: definition.schema,
+      });
+      if (!result.matches) {
+        diagnostics.push(
+          createDiagnostic({
+            filePath: context.path,
+            predicateName: "declareTypes",
+            message: `Type "${resolvedName}" ${result.reason}`,
+            conventionName,
+            line: typeDefinition?.pos.line ?? symbol.pos.line,
+            column: typeDefinition?.pos.column ?? symbol.pos.column,
+            severity,
+          })
+        );
+      }
     }
   }
 

--- a/packages/konsistent/src/typescript/predicates/export-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
 import type { FileStructure } from "../types.js";
 import { checkExportTypes } from "./export-types.js";
 
@@ -233,5 +234,93 @@ describe("checkExportTypes", () => {
       conventionName: "type-exports",
     });
     expect(result[0].conventionName).toBe("type-exports");
+  });
+
+  it("validates a partial object schema for a local type export", () => {
+    const result = checkExportTypes({
+      expected: [
+        {
+          name: "ModuleSettings",
+          schema: {
+            type: "object",
+            properties: {
+              model: { type: "string" },
+              timeout: { type: "number" },
+            },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: `
+          export type ModuleSettings = {
+            model?: string;
+            timeout?: number;
+            reasoning?: "low" | "medium" | "high";
+          };
+        `,
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("reports a local exported type missing a configured property", () => {
+    const result = checkExportTypes({
+      expected: [
+        {
+          name: "ModuleSettings",
+          schema: {
+            type: "object",
+            properties: { timeout: { type: "number" } },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: "export type ModuleSettings = { model?: string };",
+      }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe(
+      'Type "ModuleSettings" must define property "timeout"'
+    );
+  });
+
+  it("validates schemas for exported interfaces", () => {
+    const result = checkExportTypes({
+      expected: [
+        {
+          name: "Settings",
+          schema: {
+            type: "object",
+            properties: { enabled: { type: "boolean" } },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: "export interface Settings { enabled?: boolean }",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("requires a local definition for schema-constrained re-exports", () => {
+    const result = checkExportTypes({
+      expected: [
+        {
+          name: "Settings",
+          schema: { type: "object", properties: {} },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'export type { Settings } from "./settings";',
+      }),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe(
+      'Type "Settings" must have a local type definition'
+    );
   });
 });

--- a/packages/konsistent/src/typescript/predicates/export-types.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.ts
@@ -1,10 +1,16 @@
+import type {
+  ExportTypeDefinitionV1,
+  TypeDefinitionV1,
+} from "@konsistent/convention";
 import type { PredicateContext } from "../../core/context.js";
 import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
 import { createDiagnostic } from "../../core/diagnostics.js";
+import { matchTypeDefinitionSchema } from "../constant-type-schema.js";
 import type { FileStructure } from "../types.js";
+import { findTypeDefinition } from "./declaration-utils.js";
 
 export function checkExportTypes(opts: {
-  expected: (string | { name: string; from?: string })[];
+  expected: (string | ExportTypeDefinitionV1)[];
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -16,11 +22,11 @@ export function checkExportTypes(opts: {
   for (const entry of expected) {
     const definition = typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = context.resolveTemplate(definition.name);
-    const resolvedFrom = definition.from
-      ? context.resolveTemplate(definition.from)
+    const resolvedFrom = Object.hasOwn(definition, "from")
+      ? context.resolveTemplate((definition as { from: string }).from)
       : undefined;
 
-    const found = fileStructure.exports.some(
+    const found = fileStructure.exports.find(
       (e) =>
         e.name === resolvedName &&
         e.isType &&
@@ -39,6 +45,34 @@ export function checkExportTypes(opts: {
           severity,
         })
       );
+      continue;
+    }
+
+    const schema = Object.hasOwn(definition, "schema")
+      ? (definition as TypeDefinitionV1).schema
+      : undefined;
+    if (schema) {
+      const typeDefinition = findTypeDefinition({
+        fileStructure,
+        name: resolvedName,
+      });
+      const result = matchTypeDefinitionSchema({
+        actual: typeDefinition?.typeInfo,
+        schema,
+      });
+      if (!result.matches) {
+        diagnostics.push(
+          createDiagnostic({
+            filePath: context.path,
+            predicateName: "exportTypes",
+            message: `Type "${resolvedName}" ${result.reason}`,
+            conventionName,
+            line: typeDefinition?.pos.line ?? found.pos.line,
+            column: typeDefinition?.pos.column ?? found.pos.column,
+            severity,
+          })
+        );
+      }
     }
   }
 

--- a/packages/konsistent/src/typescript/types.ts
+++ b/packages/konsistent/src/typescript/types.ts
@@ -67,6 +67,7 @@ export interface InterfaceInfo {
   extends: ExtendsClauseInfo[];
   name: string;
   pos: SourcePosition;
+  typeInfo?: TypeShapeInfo;
 }
 
 export interface ClassInfo {
@@ -98,6 +99,7 @@ export interface ConstantInfo {
 export interface TypeAliasInfo {
   name: string;
   pos: SourcePosition;
+  typeInfo?: TypeShapeInfo;
 }
 
 export type NonBarrelStatementKind =
@@ -127,4 +129,7 @@ export interface FileStructure {
   typeAliases: TypeAliasInfo[];
 }
 
-import type { ConstantTypeInfo } from "./constant-type-schema.js";
+import type {
+  ConstantTypeInfo,
+  TypeShapeInfo,
+} from "./constant-type-schema.js";


### PR DESCRIPTION
## Pull Request Description

Adds schema validation to `exportTypes` and `declareTypes`, allowing conventions to enforce structural constraints on local TypeScript type aliases and interfaces.

- Supports `schema` for declared and exported type definitions while keeping it mutually exclusive with `from`
- Enforces declaration-specific object semantics: configured properties must exist, `required` properties must be non-optional, and other configured properties must be optional
- Allows partial object validation unless `additionalProperties` is explicitly `false`
- Adds unit and end-to-end coverage for valid partial schemas and missing-property failures
- Updates the documentation and generated configuration schemas

## Relevant technical choices

Type schemas reuse the existing schema matcher and parsed type-shape representation. Validation intentionally applies only to local definitions and does not resolve re-exports, named references, inheritance, or composed types.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
