### PR TITLE
chore: update to safe `js-yaml` version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ catalogs:
 
 overrides:
   esbuild: ^0.28.1
-  read-yaml-file@1>js-yaml: 3.15.0
+  read-yaml-file@1>js-yaml: ^3.15.0
   vite: ^7.3.5
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ catalogs:
 
 overrides:
   esbuild: ^0.28.1
+  read-yaml-file@1>js-yaml: 3.15.0
   vite: ^7.3.5
 
 importers:
@@ -1212,8 +1213,8 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -2598,7 +2599,7 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -2758,7 +2759,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalog:
 
 overrides:
   esbuild: "catalog:"
+  "read-yaml-file@1>js-yaml": "3.15.0"
   vite: "catalog:"
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalog:
 
 overrides:
   esbuild: "catalog:"
-  "read-yaml-file@1>js-yaml": "3.15.0"
+  "read-yaml-file@1>js-yaml": "^3.15.0"
   vite: "catalog:"
 
 allowBuilds:


### PR DESCRIPTION
## Pull Request Description

Fixes https://github.com/vercel-labs/konsistent/security/dependabot/17 by forcing use of a safe `js-yaml` version.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)