### PR TITLE
feat(konsistent): add nested source selector handling for both `importValuesFrom` and `importTypesFrom`

### DIFF
--- a/.changeset/four-wings-brake.md
+++ b/.changeset/four-wings-brake.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): add nested source selector handling for both `importValuesFrom` and `importTypesFrom`

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -425,11 +425,49 @@ Assert that the file has at least one value import from a specific module specif
 "must": { "importValuesFrom": ["./setup", "package/*"] }
 ```
 
-The value is a string or an array of strings. When an array is used in `must`, every entry must be satisfied.
+The value is a string or an array of strings. Independent array entries are additive: every entry must be satisfied in `must`, and every entry is forbidden in `mustNot`.
 
 By default, entries match exactly. For example, `"package"` only matches `import ... from "package"` and does not match `import ... from "package/v4"`.
 
-Use a trailing `/*` to match subpaths under a prefix. For example, `"package/*"` matches `"package/v4"`, and `"@scope/pkg/*"` matches `"@scope/pkg/subpath"`. The wildcard does not match the root itself, so `"package/*"` does not match `"package"`.
+Use a trailing `/*` to select import sources below a prefix:
+
+- `"@vendor/*"` matches every package from that vendor, including package sub-entrypoints such as `"@vendor/project/testing"`.
+- `"package/*"` matches unvendored package entrypoints such as `"package/v4"`, but not the package root `"package"`.
+- `"@vendor/package/*"` matches vendored package entrypoints such as `"@vendor/package/testing"`, but not the package root `"@vendor/package"`.
+
+Other wildcard positions are invalid.
+
+Within an array, negate part of a wildcard selector by prefixing a nested pattern with `!`:
+
+```json
+"must": {
+  "importValuesFrom": [
+    "react",
+    "zod",
+    "@ai-sdk/*",
+    "!@ai-sdk/harness"
+  ]
+}
+```
+
+This requires imports from `"react"`, `"zod"`, and any package from the `@ai-sdk` vendor except the exact `"@ai-sdk/harness"` package. The exact exclusion does not exclude harness entrypoints; use `"!@ai-sdk/harness/*"` to exclude those as well.
+
+Re-include a more specific part of an excluded wildcard branch with another positive pattern:
+
+```json
+"mustNot": {
+  "importValuesFrom": [
+    "@ai-sdk/*",
+    "!@ai-sdk/harness",
+    "!@ai-sdk/harness/*",
+    "@ai-sdk/harness/bridge"
+  ]
+}
+```
+
+This forbids imports from the `@ai-sdk` vendor, allows the harness package and its entrypoints, then forbids the exact bridge entrypoint again. `must` uses the same selected set but requires at least one matching import instead.
+
+Selector rules must be strictly nested and must change the preceding selector. Dangling or unrelated exclusions, redundant re-inclusions, and overlapping independent entries are invalid configurations. For example, `"@ai-sdk/react"` cannot be combined as an independent requirement with `"@ai-sdk/*"`.
 
 ### `importTypes`
 
@@ -453,7 +491,7 @@ Assert that the file has at least one type import from a specific module specifi
 "must": { "importTypesFrom": ["./types", "@scope/package/*"] }
 ```
 
-It uses the same string or string-array shape, exact matching, and trailing `/*` subpath matching as `importValuesFrom`. Value-only and side-effect imports do not count. A mixed statement such as `import { value, type Options } from "./module"` satisfies both `importValuesFrom` and `importTypesFrom`.
+It uses the same additive array behavior, trailing `/*` selectors, exclusions, and nested re-inclusions as `importValuesFrom`. Value-only and side-effect imports do not count. A mixed statement such as `import { value, type Options } from "./module"` satisfies both `importValuesFrom` and `importTypesFrom`.
 
 ### `importValuesFromCurrentDir`
 

--- a/e2e/fixtures/import-source-selectors-invalid/konsistent.json
+++ b/e2e/fixtures/import-source-selectors-invalid/konsistent.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "invalid-import-source-selector",
+      "paths": "src/index.ts",
+      "must": {
+        "importValuesFrom": ["@ai-sdk/*", "!react"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/import-source-selectors-invalid/src/index.ts
+++ b/e2e/fixtures/import-source-selectors-invalid/src/index.ts
@@ -1,0 +1,1 @@
+export const value = true;

--- a/e2e/fixtures/import-values-and-types-from-broken/konsistent.json
+++ b/e2e/fixtures/import-values-and-types-from-broken/konsistent.json
@@ -28,6 +28,108 @@
       "name": "no-package-type-imports",
       "paths": "src/no-package-types.ts",
       "mustNot": { "importTypesFrom": "types-package/*" }
+    },
+    {
+      "name": "must-additive-value-imports",
+      "paths": "src/must-additive-values.ts",
+      "must": {
+        "importValuesFrom": [
+          "react",
+          "project/*",
+          "@vendor/*",
+          "@other/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-additive-type-imports",
+      "paths": "src/must-additive-types.ts",
+      "must": {
+        "importTypesFrom": [
+          "type-react",
+          "type-project/*",
+          "@type-vendor/*",
+          "@types/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-not-additive-value-imports",
+      "paths": "src/must-not-additive-values.ts",
+      "mustNot": {
+        "importValuesFrom": [
+          "blocked",
+          "blocked-project/*",
+          "@blocked-vendor/*",
+          "@blocked/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-not-additive-type-imports",
+      "paths": "src/must-not-additive-types.ts",
+      "mustNot": {
+        "importTypesFrom": [
+          "blocked-types",
+          "blocked-type-project/*",
+          "@blocked-types-vendor/*",
+          "@blocked-types/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-mixed-value-selector",
+      "paths": "src/must-mixed-value-selector.ts",
+      "must": {
+        "importValuesFrom": [
+          "react",
+          "zod",
+          "@ai-sdk/*",
+          "!@ai-sdk/harness",
+          "!@ai-sdk/harness/*",
+          "@ai-sdk/harness/bridge"
+        ]
+      }
+    },
+    {
+      "name": "must-mixed-type-selector",
+      "paths": "src/must-mixed-type-selector.ts",
+      "must": {
+        "importTypesFrom": [
+          "type-react",
+          "type-zod",
+          "@vendor/project/*",
+          "!@vendor/project/internal/*",
+          "@vendor/project/internal/public/*",
+          "!@vendor/project/internal/public/private"
+        ]
+      }
+    },
+    {
+      "name": "must-not-mixed-value-selector",
+      "paths": "src/must-not-mixed-value-selector.ts",
+      "mustNot": {
+        "importValuesFrom": [
+          "forbidden",
+          "@ai-sdk/*",
+          "!@ai-sdk/harness",
+          "!@ai-sdk/harness/*",
+          "@ai-sdk/harness/bridge"
+        ]
+      }
+    },
+    {
+      "name": "must-not-mixed-type-selector",
+      "paths": "src/must-not-mixed-type-selector.ts",
+      "mustNot": {
+        "importTypesFrom": [
+          "forbidden-types",
+          "@vendor/project/*",
+          "!@vendor/project/internal/*",
+          "@vendor/project/internal/public/*",
+          "!@vendor/project/internal/public/private"
+        ]
+      }
     }
   ]
 }

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-additive-types.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-additive-types.ts
@@ -1,0 +1,11 @@
+import { reactType } from "type-react";
+import { projectType } from "type-project/entrypoint";
+import { toolkitType } from "@types/toolkit/entrypoint";
+import { vendoredType } from "@type-vendor/package";
+
+export const wrongKindTypes = {
+  reactType,
+  projectType,
+  toolkitType,
+  vendoredType,
+};

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-additive-values.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-additive-values.ts
@@ -1,0 +1,7 @@
+import type React from "react";
+import { projectRoot } from "project";
+import { toolkitRoot } from "@other/toolkit";
+import { vendorName } from "@vendor";
+
+export type MissingValueImport = React;
+export const unmatchedValues = { projectRoot, toolkitRoot, vendorName };

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-mixed-type-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-mixed-type-selector.ts
@@ -1,0 +1,7 @@
+import type { ReactType } from "type-react";
+import type { ZodType } from "type-zod";
+import type { PrivateApi } from "@vendor/project/internal/public/private";
+import { publicApi } from "@vendor/project/internal/public/api";
+
+export type ExcludedTypes = ReactType | ZodType | PrivateApi;
+export const wrongKindPublicApi = publicApi;

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-mixed-value-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-mixed-value-selector.ts
@@ -1,0 +1,8 @@
+import React from "react";
+import { z } from "zod";
+import type { Core } from "@ai-sdk/core";
+import { harness } from "@ai-sdk/harness";
+import { testing } from "@ai-sdk/harness/testing";
+
+export type WrongKindCore = Core;
+export const excludedValues = { React, z, harness, testing };

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-not-additive-types.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-not-additive-types.ts
@@ -1,0 +1,10 @@
+import type { BlockedType } from "blocked-types";
+import type { BlockedProject } from "blocked-type-project/entrypoint";
+import type { BlockedToolkit } from "@blocked-types/toolkit/entrypoint";
+import type { BlockedVendor } from "@blocked-types-vendor/package";
+
+export type BlockedTypes =
+  | BlockedType
+  | BlockedProject
+  | BlockedToolkit
+  | BlockedVendor;

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-not-additive-values.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-not-additive-values.ts
@@ -1,0 +1,11 @@
+import { blocked } from "blocked";
+import { blockedProject } from "blocked-project/entrypoint";
+import { blockedToolkit } from "@blocked/toolkit/entrypoint";
+import { blockedVendor } from "@blocked-vendor/package";
+
+export const blockedValues = {
+  blocked,
+  blockedProject,
+  blockedToolkit,
+  blockedVendor,
+};

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-not-mixed-type-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-not-mixed-type-selector.ts
@@ -1,0 +1,4 @@
+import type { ForbiddenType } from "forbidden-types";
+import type { PublicApi } from "@vendor/project/internal/public/api";
+
+export type ForbiddenTypes = ForbiddenType | PublicApi;

--- a/e2e/fixtures/import-values-and-types-from-broken/src/must-not-mixed-value-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from-broken/src/must-not-mixed-value-selector.ts
@@ -1,0 +1,4 @@
+import { forbidden } from "forbidden";
+import { bridge } from "@ai-sdk/harness/bridge";
+
+export const forbiddenValues = { forbidden, bridge };

--- a/e2e/fixtures/import-values-and-types-from/konsistent.json
+++ b/e2e/fixtures/import-values-and-types-from/konsistent.json
@@ -28,6 +28,108 @@
       "name": "no-package-type-imports",
       "paths": "src/no-package-types.ts",
       "mustNot": { "importTypesFrom": "types-package/*" }
+    },
+    {
+      "name": "must-additive-value-imports",
+      "paths": "src/must-additive-values.ts",
+      "must": {
+        "importValuesFrom": [
+          "react",
+          "project/*",
+          "@vendor/*",
+          "@other/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-additive-type-imports",
+      "paths": "src/must-additive-types.ts",
+      "must": {
+        "importTypesFrom": [
+          "type-react",
+          "type-project/*",
+          "@type-vendor/*",
+          "@types/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-not-additive-value-imports",
+      "paths": "src/must-not-additive-values.ts",
+      "mustNot": {
+        "importValuesFrom": [
+          "blocked",
+          "blocked-project/*",
+          "@blocked-vendor/*",
+          "@blocked/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-not-additive-type-imports",
+      "paths": "src/must-not-additive-types.ts",
+      "mustNot": {
+        "importTypesFrom": [
+          "blocked-types",
+          "blocked-type-project/*",
+          "@blocked-types-vendor/*",
+          "@blocked-types/toolkit/*"
+        ]
+      }
+    },
+    {
+      "name": "must-mixed-value-selector",
+      "paths": "src/must-mixed-value-selector.ts",
+      "must": {
+        "importValuesFrom": [
+          "react",
+          "zod",
+          "@ai-sdk/*",
+          "!@ai-sdk/harness",
+          "!@ai-sdk/harness/*",
+          "@ai-sdk/harness/bridge"
+        ]
+      }
+    },
+    {
+      "name": "must-mixed-type-selector",
+      "paths": "src/must-mixed-type-selector.ts",
+      "must": {
+        "importTypesFrom": [
+          "type-react",
+          "type-zod",
+          "@vendor/project/*",
+          "!@vendor/project/internal/*",
+          "@vendor/project/internal/public/*",
+          "!@vendor/project/internal/public/private"
+        ]
+      }
+    },
+    {
+      "name": "must-not-mixed-value-selector",
+      "paths": "src/must-not-mixed-value-selector.ts",
+      "mustNot": {
+        "importValuesFrom": [
+          "forbidden",
+          "@ai-sdk/*",
+          "!@ai-sdk/harness",
+          "!@ai-sdk/harness/*",
+          "@ai-sdk/harness/bridge"
+        ]
+      }
+    },
+    {
+      "name": "must-not-mixed-type-selector",
+      "paths": "src/must-not-mixed-type-selector.ts",
+      "mustNot": {
+        "importTypesFrom": [
+          "forbidden-types",
+          "@vendor/project/*",
+          "!@vendor/project/internal/*",
+          "@vendor/project/internal/public/*",
+          "!@vendor/project/internal/public/private"
+        ]
+      }
     }
   ]
 }

--- a/e2e/fixtures/import-values-and-types-from/src/must-additive-types.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-additive-types.ts
@@ -1,0 +1,10 @@
+import type { ReactType } from "type-react";
+import type { ProjectType } from "type-project/entrypoint";
+import type { VendoredType } from "@type-vendor/package/entrypoint";
+import type { ToolkitType } from "@types/toolkit/entrypoint";
+
+export type AdditiveTypes =
+  | ReactType
+  | ProjectType
+  | VendoredType
+  | ToolkitType;

--- a/e2e/fixtures/import-values-and-types-from/src/must-additive-values.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-additive-values.ts
@@ -1,0 +1,11 @@
+import React from "react";
+import { entrypoint } from "project/entrypoint";
+import { vendoredPackage } from "@vendor/package";
+import { toolkit } from "@other/toolkit/entrypoint";
+
+export const additiveValues = {
+  React,
+  entrypoint,
+  vendoredPackage,
+  toolkit,
+};

--- a/e2e/fixtures/import-values-and-types-from/src/must-mixed-type-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-mixed-type-selector.ts
@@ -1,0 +1,5 @@
+import type { ReactType } from "type-react";
+import type { ZodType } from "type-zod";
+import type { PublicApi } from "@vendor/project/internal/public/api";
+
+export type SelectedTypes = ReactType | ZodType | PublicApi;

--- a/e2e/fixtures/import-values-and-types-from/src/must-mixed-value-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-mixed-value-selector.ts
@@ -1,0 +1,5 @@
+import React from "react";
+import { z } from "zod";
+import { bridge } from "@ai-sdk/harness/bridge";
+
+export const selectedValues = { React, z, bridge };

--- a/e2e/fixtures/import-values-and-types-from/src/must-not-additive-types.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-not-additive-types.ts
@@ -1,0 +1,10 @@
+import type { AllowedProjectRoot } from "blocked-type-project";
+import type { AllowedToolkitRoot } from "@blocked-types/toolkit";
+import type { OtherPackage } from "@allowed-types-vendor/package";
+import type { OtherType } from "allowed-types";
+
+export type AllowedAdditiveTypes =
+  | AllowedProjectRoot
+  | AllowedToolkitRoot
+  | OtherPackage
+  | OtherType;

--- a/e2e/fixtures/import-values-and-types-from/src/must-not-additive-values.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-not-additive-values.ts
@@ -1,0 +1,11 @@
+import { allowedProjectRoot } from "blocked-project";
+import { allowedToolkitRoot } from "@blocked/toolkit";
+import { otherPackage } from "@allowed-vendor/package";
+import { otherValue } from "allowed";
+
+export const allowedAdditiveValues = {
+  allowedProjectRoot,
+  allowedToolkitRoot,
+  otherPackage,
+  otherValue,
+};

--- a/e2e/fixtures/import-values-and-types-from/src/must-not-mixed-type-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-not-mixed-type-selector.ts
@@ -1,0 +1,4 @@
+import type { PrivateApi } from "@vendor/project/internal/public/private";
+import type { SecretApi } from "@vendor/project/internal/secret";
+
+export type AllowedTypes = PrivateApi | SecretApi;

--- a/e2e/fixtures/import-values-and-types-from/src/must-not-mixed-value-selector.ts
+++ b/e2e/fixtures/import-values-and-types-from/src/must-not-mixed-value-selector.ts
@@ -1,0 +1,4 @@
+import { harness } from "@ai-sdk/harness";
+import { testing } from "@ai-sdk/harness/testing";
+
+export const allowedValues = { harness, testing };

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -12,8 +12,8 @@ const cliBinary = resolve(
 
 const fixturesDir = resolve(import.meta.dirname, "fixtures");
 
-function runCli(opts: { cwd: string }) {
-  return execFile("node", [cliBinary, "check"], {
+function runCli(opts: { cwd: string; args?: string[] }) {
+  return execFile("node", [cliBinary, ...(opts.args ?? ["check"])], {
     cwd: opts.cwd,
     env: { ...process.env, GITHUB_ACTIONS: "" },
   });
@@ -204,6 +204,45 @@ describe("import-values-and-types-from-broken fixture", () => {
       expect(error.stdout).toContain('Forbidden import from "package/*"');
       expect(error.stdout).toContain(
         'Forbidden type import from "types-package/*"'
+      );
+      expect(error.stdout).toContain('Missing import from "@vendor/*"');
+      expect(error.stdout).toContain(
+        'Missing type import from "@type-vendor/*"'
+      );
+      expect(error.stdout).toContain(
+        'Forbidden import from "@blocked-vendor/*"'
+      );
+      expect(error.stdout).toContain(
+        'Forbidden type import from "@blocked-types-vendor/*"'
+      );
+      expect(error.stdout).toContain('Missing import from "@ai-sdk/*"');
+      expect(error.stdout).toContain(
+        'Missing type import from "@vendor/project/*"'
+      );
+      expect(error.stdout).toContain('Forbidden import from "@ai-sdk/*"');
+      expect(error.stdout).toContain(
+        'Forbidden type import from "@vendor/project/*"'
+      );
+    }
+  });
+});
+
+describe("import-source-selectors-invalid fixture", () => {
+  const cwd = resolve(fixturesDir, "import-source-selectors-invalid");
+
+  it("fails konsistent validate for an unrelated exclusion", async () => {
+    try {
+      await runCli({ cwd, args: ["validate"] });
+      expect.fail("Expected validate to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as {
+        stderr: string;
+        code: number;
+        status: number;
+      };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stderr).toContain(
+        'Import source pattern "react" must be strictly nested under wildcard selector "@ai-sdk/*"'
       );
     }
   });

--- a/packages/convention/src/import-source-selector.test.ts
+++ b/packages/convention/src/import-source-selector.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileImportSourceConstraints,
+  doesImportSourceConstraintMatch,
+  importSourceConstraintValue,
+} from "./import-source-selector.js";
+
+function compile(expected: string | string[]) {
+  const result = compileImportSourceConstraints({ expected });
+  expect(result.success).toBe(true);
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+  return result.constraints;
+}
+
+function expectInvalid(opts: { expected: string | string[]; message: string }) {
+  const result = compileImportSourceConstraints({ expected: opts.expected });
+  expect(result.success).toBe(false);
+  if (result.success) {
+    throw new Error("Expected import source constraints to be invalid.");
+  }
+  expect(result.error).toContain(opts.message);
+}
+
+describe("compileImportSourceConstraints", () => {
+  it("keeps non-overlapping exact and wildcard entries additive", () => {
+    const constraints = compile([
+      "react",
+      "zod",
+      "package/*",
+      "@vendor/*",
+      "@other/project/*",
+    ]);
+
+    expect(constraints.map((constraint) => constraint.source)).toEqual([
+      "react",
+      "zod",
+      "package/*",
+      "@vendor/*",
+      "@other/project/*",
+    ]);
+  });
+
+  it("compiles sibling exclusions and a nested re-inclusion", () => {
+    const constraints = compile([
+      "@ai-sdk/*",
+      "!@ai-sdk/harness",
+      "!@ai-sdk/harness/*",
+      "@ai-sdk/harness/bridge",
+    ]);
+
+    expect(constraints).toHaveLength(1);
+    expect(importSourceConstraintValue({ constraint: constraints[0] })).toEqual(
+      [
+        "@ai-sdk/*",
+        "!@ai-sdk/harness",
+        "!@ai-sdk/harness/*",
+        "@ai-sdk/harness/bridge",
+      ]
+    );
+  });
+
+  it("supports nested wildcard re-inclusions and exclusions", () => {
+    const constraints = compile([
+      "@vendor/project/*",
+      "!@vendor/project/internal/*",
+      "@vendor/project/internal/public/*",
+      "!@vendor/project/internal/public/private",
+    ]);
+
+    expect(constraints).toHaveLength(1);
+  });
+
+  it("validates statically nested template patterns", () => {
+    const constraints = compile([
+      "@${vendor}/*",
+      "!@${vendor}/harness/*",
+      "@${vendor}/harness/bridge",
+    ]);
+
+    expect(constraints).toHaveLength(1);
+  });
+
+  it("rejects a negated string", () => {
+    expectInvalid({
+      expected: "!@vendor/project",
+      message: "may only be used in arrays",
+    });
+  });
+
+  it("rejects unsupported wildcard positions", () => {
+    expectInvalid({
+      expected: ["@vendor/*/internal"],
+      message: 'only use "*" as a trailing "/*"',
+    });
+  });
+
+  it("rejects a wildcard without a prefix", () => {
+    expectInvalid({
+      expected: ["/*"],
+      message: 'include a prefix before "/*"',
+    });
+  });
+
+  it("rejects a negation without an active wildcard selector", () => {
+    expectInvalid({
+      expected: ["react", "!zod"],
+      message: "must follow a wildcard selector",
+    });
+  });
+
+  it("rejects an unrelated exclusion", () => {
+    expectInvalid({
+      expected: ["@vendor/*", "!react"],
+      message: "must be strictly nested",
+    });
+  });
+
+  it("rejects an overlapping exact constraint before a wildcard", () => {
+    expectInvalid({
+      expected: ["@ai-sdk/react", "@ai-sdk/*"],
+      message: "overlaps independent constraint",
+    });
+  });
+
+  it("rejects an overlapping exact constraint after a wildcard", () => {
+    expectInvalid({
+      expected: ["@ai-sdk/*", "@ai-sdk/react"],
+      message: "does not change wildcard selector",
+    });
+  });
+
+  it("rejects a positive entry that was not excluded", () => {
+    expectInvalid({
+      expected: ["@ai-sdk/*", "!@ai-sdk/harness", "@ai-sdk/react"],
+      message: "does not change wildcard selector",
+    });
+  });
+
+  it("rejects a re-inclusion equal to its exclusion", () => {
+    expectInvalid({
+      expected: ["@ai-sdk/*", "!@ai-sdk/harness", "@ai-sdk/harness"],
+      message: "must be more specific",
+    });
+  });
+
+  it("rejects a rule spanning included and excluded branches", () => {
+    expectInvalid({
+      expected: [
+        "@ai-sdk/*",
+        "!@ai-sdk/harness/internal/*",
+        "!@ai-sdk/harness/*",
+      ],
+      message: "overlaps both included and excluded branches",
+    });
+  });
+
+  it("rejects modifiers after an unrelated constraint closes a selector", () => {
+    expectInvalid({
+      expected: ["@ai-sdk/*", "react", "!@ai-sdk/harness"],
+      message: "must follow a wildcard selector",
+    });
+  });
+});
+
+describe("doesImportSourceConstraintMatch", () => {
+  it("matches package roots and sub-entrypoints under a vendor wildcard", () => {
+    const [constraint] = compile("@vendor/*");
+
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project",
+        constraint,
+      })
+    ).toBe(true);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project/entrypoint",
+        constraint,
+      })
+    ).toBe(true);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@other/project",
+        constraint,
+      })
+    ).toBe(false);
+  });
+
+  it("matches unvendored and vendored entrypoints but not package roots", () => {
+    const [unvendored] = compile("project/*");
+    const [vendored] = compile("@vendor/project/*");
+
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "project/entrypoint",
+        constraint: unvendored,
+      })
+    ).toBe(true);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "project",
+        constraint: unvendored,
+      })
+    ).toBe(false);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project/entrypoint",
+        constraint: vendored,
+      })
+    ).toBe(true);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project",
+        constraint: vendored,
+      })
+    ).toBe(false);
+  });
+
+  it("applies exclusions and nested re-inclusions", () => {
+    const [constraint] = compile([
+      "@ai-sdk/*",
+      "!@ai-sdk/harness",
+      "!@ai-sdk/harness/*",
+      "@ai-sdk/harness/bridge",
+    ]);
+
+    for (const source of ["@ai-sdk/core", "@ai-sdk/core/testing"]) {
+      expect(doesImportSourceConstraintMatch({ source, constraint })).toBe(
+        true
+      );
+    }
+    for (const source of [
+      "@ai-sdk/harness",
+      "@ai-sdk/harness/testing",
+      "@ai-sdk/harness/bridge/testing",
+    ]) {
+      expect(doesImportSourceConstraintMatch({ source, constraint })).toBe(
+        false
+      );
+    }
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@ai-sdk/harness/bridge",
+        constraint,
+      })
+    ).toBe(true);
+  });
+
+  it("applies deeper wildcard toggles in order", () => {
+    const [constraint] = compile([
+      "@vendor/project/*",
+      "!@vendor/project/internal/*",
+      "@vendor/project/internal/public/*",
+      "!@vendor/project/internal/public/private",
+    ]);
+
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project/internal/secret",
+        constraint,
+      })
+    ).toBe(false);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project/internal/public/api",
+        constraint,
+      })
+    ).toBe(true);
+    expect(
+      doesImportSourceConstraintMatch({
+        source: "@vendor/project/internal/public/private",
+        constraint,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/convention/src/import-source-selector.ts
+++ b/packages/convention/src/import-source-selector.ts
@@ -1,0 +1,413 @@
+export interface ImportSourcePattern {
+  source: string;
+  wildcard: boolean;
+}
+
+export interface ImportSourceSelectorRule extends ImportSourcePattern {
+  selected: boolean;
+}
+
+export interface ExactImportSourceConstraint {
+  kind: "exact";
+  source: string;
+}
+
+export interface ImportSourceSelectorConstraint {
+  kind: "selector";
+  rules: ImportSourceSelectorRule[];
+  source: string;
+}
+
+export type ImportSourceConstraint =
+  | ExactImportSourceConstraint
+  | ImportSourceSelectorConstraint;
+
+export type CompileImportSourceConstraintsResult =
+  | { success: true; constraints: ImportSourceConstraint[] }
+  | { success: false; index?: number; error: string };
+
+function parsePattern(opts: { configuredSource: string; index?: number }):
+  | {
+      success: true;
+      negated: boolean;
+      pattern: ImportSourcePattern;
+    }
+  | { success: false; index?: number; error: string } {
+  const negated = opts.configuredSource.startsWith("!");
+  const source = negated
+    ? opts.configuredSource.slice(1)
+    : opts.configuredSource;
+
+  if (source.length === 0) {
+    return {
+      success: false,
+      index: opts.index,
+      error: "Import source patterns must not be empty.",
+    };
+  }
+
+  const firstAsterisk = source.indexOf("*");
+  if (
+    firstAsterisk !== -1 &&
+    !(source.endsWith("/*") && firstAsterisk === source.length - 1)
+  ) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.configuredSource}" may only use "*" as a trailing "/*".`,
+    };
+  }
+
+  if (source === "/*") {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.configuredSource}" must include a prefix before "/*".`,
+    };
+  }
+
+  return {
+    success: true,
+    negated,
+    pattern: {
+      source,
+      wildcard: source.endsWith("/*"),
+    },
+  };
+}
+
+function wildcardPrefix(pattern: ImportSourcePattern): string {
+  return pattern.source.slice(0, -2);
+}
+
+function patternsEqual(opts: {
+  left: ImportSourcePattern;
+  right: ImportSourcePattern;
+}): boolean {
+  return (
+    opts.left.source === opts.right.source &&
+    opts.left.wildcard === opts.right.wildcard
+  );
+}
+
+function patternContains(opts: {
+  parent: ImportSourcePattern;
+  child: ImportSourcePattern;
+  strict?: boolean;
+}): boolean {
+  if (patternsEqual({ left: opts.parent, right: opts.child })) {
+    return opts.strict !== true;
+  }
+  if (!opts.parent.wildcard) {
+    return false;
+  }
+
+  const prefix = wildcardPrefix(opts.parent);
+  if (opts.child.wildcard) {
+    return wildcardPrefix(opts.child).startsWith(`${prefix}/`);
+  }
+  return opts.child.source.startsWith(`${prefix}/`);
+}
+
+function patternsOverlap(opts: {
+  left: ImportSourcePattern;
+  right: ImportSourcePattern;
+}): boolean {
+  return (
+    patternContains({ parent: opts.left, child: opts.right }) ||
+    patternContains({ parent: opts.right, child: opts.left })
+  );
+}
+
+function constraintPattern(
+  constraint: ImportSourceConstraint
+): ImportSourcePattern {
+  return {
+    source: constraint.source,
+    wildcard: constraint.kind === "selector",
+  };
+}
+
+function selectorRules(
+  constraint: ImportSourceSelectorConstraint
+): ImportSourceSelectorRule[] {
+  return [
+    { source: constraint.source, wildcard: true, selected: true },
+    ...constraint.rules,
+  ];
+}
+
+function getUniformSelection(opts: {
+  selector: ImportSourceSelectorConstraint;
+  pattern: ImportSourcePattern;
+}):
+  | { success: true; selected: boolean; ancestor: ImportSourceSelectorRule }
+  | { success: false } {
+  const rules = selectorRules(opts.selector);
+  const ancestors = rules.filter((rule) =>
+    patternContains({ parent: rule, child: opts.pattern })
+  );
+  const ancestor = ancestors.sort(
+    (left, right) => right.source.length - left.source.length
+  )[0];
+
+  if (!ancestor) {
+    return { success: false };
+  }
+
+  const hasDescendant = rules.some((rule) =>
+    patternContains({
+      parent: opts.pattern,
+      child: rule,
+      strict: true,
+    })
+  );
+  if (hasDescendant) {
+    return { success: false };
+  }
+
+  return { success: true, selected: ancestor.selected, ancestor };
+}
+
+function addSelectorRule(opts: {
+  selector: ImportSourceSelectorConstraint;
+  pattern: ImportSourcePattern;
+  selected: boolean;
+  index: number;
+}): { success: true } | { success: false; index: number; error: string } {
+  if (
+    !patternContains({
+      parent: constraintPattern(opts.selector),
+      child: opts.pattern,
+      strict: true,
+    })
+  ) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.pattern.source}" must be strictly nested under wildcard selector "${opts.selector.source}".`,
+    };
+  }
+
+  const selection = getUniformSelection({
+    selector: opts.selector,
+    pattern: opts.pattern,
+  });
+  if (!selection.success) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.pattern.source}" overlaps both included and excluded branches of wildcard selector "${opts.selector.source}".`,
+    };
+  }
+  if (
+    !patternContains({
+      parent: selection.ancestor,
+      child: opts.pattern,
+      strict: true,
+    })
+  ) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.pattern.source}" must be more specific than the rule it modifies.`,
+    };
+  }
+  if (selection.selected === opts.selected) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.pattern.source}" does not change wildcard selector "${opts.selector.source}".`,
+    };
+  }
+
+  opts.selector.rules.push({ ...opts.pattern, selected: opts.selected });
+  return { success: true };
+}
+
+type AddConfiguredPatternResult =
+  | {
+      success: true;
+      activeSelector: ImportSourceSelectorConstraint | undefined;
+    }
+  | { success: false; index: number; error: string };
+
+function addNegatedPattern(opts: {
+  expectedIsArray: boolean;
+  configuredSource: string;
+  pattern: ImportSourcePattern;
+  activeSelector: ImportSourceSelectorConstraint | undefined;
+  index: number;
+}): AddConfiguredPatternResult {
+  if (!opts.expectedIsArray) {
+    return {
+      success: false,
+      index: opts.index,
+      error: "Negated import source patterns may only be used in arrays.",
+    };
+  }
+  if (!opts.activeSelector) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Negated import source pattern "${opts.configuredSource}" must follow a wildcard selector.`,
+    };
+  }
+  const added = addSelectorRule({
+    selector: opts.activeSelector,
+    pattern: opts.pattern,
+    selected: false,
+    index: opts.index,
+  });
+  if (!added.success) {
+    return added;
+  }
+  return { success: true, activeSelector: opts.activeSelector };
+}
+
+function addPositivePattern(opts: {
+  pattern: ImportSourcePattern;
+  constraints: ImportSourceConstraint[];
+  activeSelector: ImportSourceSelectorConstraint | undefined;
+  index: number;
+}): AddConfiguredPatternResult {
+  if (
+    opts.activeSelector &&
+    patternContains({
+      parent: constraintPattern(opts.activeSelector),
+      child: opts.pattern,
+    })
+  ) {
+    const added = addSelectorRule({
+      selector: opts.activeSelector,
+      pattern: opts.pattern,
+      selected: true,
+      index: opts.index,
+    });
+    return added.success
+      ? { success: true, activeSelector: opts.activeSelector }
+      : added;
+  }
+
+  const overlapping = opts.constraints.find((constraint) =>
+    patternsOverlap({
+      left: constraintPattern(constraint),
+      right: opts.pattern,
+    })
+  );
+  if (overlapping) {
+    return {
+      success: false,
+      index: opts.index,
+      error: `Import source pattern "${opts.pattern.source}" overlaps independent constraint "${overlapping.source}".`,
+    };
+  }
+
+  if (!opts.pattern.wildcard) {
+    opts.constraints.push({ kind: "exact", source: opts.pattern.source });
+    return { success: true, activeSelector: undefined };
+  }
+
+  const selector: ImportSourceSelectorConstraint = {
+    kind: "selector",
+    source: opts.pattern.source,
+    rules: [],
+  };
+  opts.constraints.push(selector);
+  return { success: true, activeSelector: selector };
+}
+
+export function compileImportSourceConstraints(opts: {
+  expected: string | string[];
+}): CompileImportSourceConstraintsResult {
+  const configuredSources =
+    typeof opts.expected === "string" ? [opts.expected] : opts.expected;
+  const constraints: ImportSourceConstraint[] = [];
+  let activeSelector: ImportSourceSelectorConstraint | undefined;
+
+  for (let index = 0; index < configuredSources.length; index++) {
+    const configuredSource = configuredSources[index];
+    if (configuredSource === undefined) {
+      continue;
+    }
+    const parsed = parsePattern({ configuredSource, index });
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    const added = parsed.negated
+      ? addNegatedPattern({
+          expectedIsArray: Array.isArray(opts.expected),
+          configuredSource,
+          pattern: parsed.pattern,
+          activeSelector,
+          index,
+        })
+      : addPositivePattern({
+          pattern: parsed.pattern,
+          constraints,
+          activeSelector,
+          index,
+        });
+    if (!added.success) {
+      return added;
+    }
+    activeSelector = added.activeSelector;
+  }
+
+  return { success: true, constraints };
+}
+
+function doesPatternMatch(opts: {
+  source: string;
+  pattern: ImportSourcePattern;
+}): boolean {
+  if (!opts.pattern.wildcard) {
+    return opts.source === opts.pattern.source;
+  }
+  const prefix = wildcardPrefix(opts.pattern);
+  return (
+    opts.source.length > prefix.length + 1 &&
+    opts.source.startsWith(`${prefix}/`)
+  );
+}
+
+export function doesImportSourceConstraintMatch(opts: {
+  source: string;
+  constraint: ImportSourceConstraint;
+}): boolean {
+  if (opts.constraint.kind === "exact") {
+    return opts.source === opts.constraint.source;
+  }
+
+  if (
+    !doesPatternMatch({
+      source: opts.source,
+      pattern: constraintPattern(opts.constraint),
+    })
+  ) {
+    return false;
+  }
+
+  let selected = true;
+  for (const rule of opts.constraint.rules) {
+    if (doesPatternMatch({ source: opts.source, pattern: rule })) {
+      selected = rule.selected;
+    }
+  }
+  return selected;
+}
+
+export function importSourceConstraintValue(opts: {
+  constraint: ImportSourceConstraint;
+}): string | string[] {
+  if (opts.constraint.kind === "exact" || opts.constraint.rules.length === 0) {
+    return opts.constraint.source;
+  }
+  return [
+    opts.constraint.source,
+    ...opts.constraint.rules.map((rule) =>
+      rule.selected ? rule.source : `!${rule.source}`
+    ),
+  ];
+}

--- a/packages/convention/src/index.ts
+++ b/packages/convention/src/index.ts
@@ -25,6 +25,19 @@ export {
   TypeDefinitionV1Schema,
 } from "./constant-schema.js";
 export type {
+  CompileImportSourceConstraintsResult,
+  ExactImportSourceConstraint,
+  ImportSourceConstraint,
+  ImportSourcePattern,
+  ImportSourceSelectorConstraint,
+  ImportSourceSelectorRule,
+} from "./import-source-selector.js";
+export {
+  compileImportSourceConstraints,
+  doesImportSourceConstraintMatch,
+  importSourceConstraintValue,
+} from "./import-source-selector.js";
+export type {
   ClassDefinitionV1,
   DeclarationDefinitionV1,
   ExportDefinitionV1,

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -5,6 +5,7 @@ import {
   ExportTypeDefinitionV1Schema,
   TypeDefinitionV1Schema,
 } from "./constant-schema.js";
+import { compileImportSourceConstraints } from "./import-source-selector.js";
 
 export const ExportDefinitionV1Schema = z.strictObject({
   name: z.string(),
@@ -59,6 +60,18 @@ const ExactImportSourcePredicateV1Schema = z.union([
   z.string(),
   z.array(z.string()),
 ]);
+const ImportSourceSelectorPredicateV1Schema =
+  ExactImportSourcePredicateV1Schema.superRefine((value, context) => {
+    const result = compileImportSourceConstraints({ expected: value });
+    if (result.success) {
+      return;
+    }
+    context.addIssue({
+      code: "custom",
+      message: result.error,
+      path: result.index === undefined ? [] : [result.index],
+    });
+  });
 
 export const MustPredicatesV1Schema = z.strictObject({
   haveType: z.enum(["file", "directory"]).optional(),
@@ -109,8 +122,8 @@ export const MustPredicatesV1Schema = z.strictObject({
     deprecated: true,
     description: "Use importValues instead.",
   }),
-  importValuesFrom: ExactImportSourcePredicateV1Schema.optional(),
-  importTypesFrom: ExactImportSourcePredicateV1Schema.optional(),
+  importValuesFrom: ImportSourceSelectorPredicateV1Schema.optional(),
+  importTypesFrom: ImportSourceSelectorPredicateV1Schema.optional(),
   /**
    * @deprecated Use importValuesFrom or importTypesFrom instead.
    */

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -195,6 +195,66 @@ describe("ConfigV1Schema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts nested import source selectors", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            importValuesFrom: [
+              "react",
+              "@ai-sdk/*",
+              "!@ai-sdk/harness/*",
+              "@ai-sdk/harness/bridge",
+            ],
+          },
+          mustNot: {
+            importTypesFrom: [
+              "@vendor/project/*",
+              "!@vendor/project/internal/*",
+              "@vendor/project/internal/public/*",
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects dangling import source exclusions", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            importValuesFrom: ["react", "!@ai-sdk/harness"],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects redundant overlapping import source constraints", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          mustNot: {
+            importTypesFrom: ["@ai-sdk/react", "@ai-sdk/*"],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects config with missing version", () => {
     const result = ConfigV1Schema.safeParse({
       conventions: [],

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -391,6 +391,111 @@ describe("run", () => {
     ]);
   });
 
+  it("allows excluded value imports in a mustNot selector", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importValuesFrom: [
+              "@ai-sdk/*",
+              "!@ai-sdk/harness",
+              "!@ai-sdk/harness/*",
+              "@ai-sdk/harness/bridge",
+            ],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            "import { harness } from '@ai-sdk/harness';",
+            "import { testing } from '@ai-sdk/harness/testing';",
+          ].join("\n"),
+        ],
+      ]),
+    });
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("forbids selected and re-included value imports as one selector", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importValuesFrom: [
+              "@ai-sdk/*",
+              "!@ai-sdk/harness",
+              "!@ai-sdk/harness/*",
+              "@ai-sdk/harness/bridge",
+            ],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            "import { core } from '@ai-sdk/core';",
+            "import { bridge } from '@ai-sdk/harness/bridge';",
+          ].join("\n"),
+        ],
+      ]),
+    });
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].predicateName).toBe("mustNot.importValuesFrom");
+    expect(diagnostics[0].message).toBe('Forbidden import from "@ai-sdk/*"');
+  });
+
+  it("groups type import selectors while keeping exact constraints additive", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importTypesFrom: ["react", "@vendor/*", "!@vendor/allowed"],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            "import type { ReactNode } from 'react';",
+            "import type { Tool } from '@vendor/project';",
+          ].join("\n"),
+        ],
+      ]),
+    });
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      'Forbidden type import from "react"',
+      'Forbidden type import from "@vendor/*"',
+    ]);
+  });
+
   it("applies block metadata to mustNot predicates", async () => {
     const config: ConfigV1 = {
       version: "v1",

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -1,4 +1,8 @@
 import { basename, dirname, join, posix } from "node:path";
+import {
+  compileImportSourceConstraints,
+  importSourceConstraintValue,
+} from "@konsistent/convention";
 import type {
   ConfigV1,
   MustBlockV1,
@@ -490,6 +494,7 @@ const TS_PREDICATE_HANDLERS: Record<
           expected: must.importFrom,
           importKind: "either",
           predicateName: "importFrom",
+          selectorSyntax: false,
           context,
           fileStructure,
           conventionName,
@@ -887,6 +892,28 @@ function buildMustNotChecks(opts: {
   for (const key of Object.keys(opts.mustNot)) {
     const value = opts.mustNot[key as keyof MustPredicatesV1];
     if (value === undefined) {
+      continue;
+    }
+    if (
+      Array.isArray(value) &&
+      (key === "importValuesFrom" || key === "importTypesFrom")
+    ) {
+      const compiled = compileImportSourceConstraints({
+        expected: value as string[],
+      });
+      if (!compiled.success) {
+        throw new Error(compiled.error);
+      }
+      for (const constraint of compiled.constraints) {
+        checks.push({
+          key,
+          predicate: buildSingletonPredicate({
+            key,
+            value: importSourceConstraintValue({ constraint }),
+          }),
+          value: constraint.source,
+        });
+      }
       continue;
     }
     if (Array.isArray(value) && ITEM_LEVEL_MUST_NOT_PREDICATES.has(key)) {

--- a/packages/konsistent/src/typescript/predicates/import-source-exact.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import-source-exact.test.ts
@@ -93,6 +93,19 @@ describe("checkExactImportSource", () => {
     expect(result).toEqual([]);
   });
 
+  it("matches package roots and sub-entrypoints from a vendor", () => {
+    for (const source of ["@vendor/project", "@vendor/project/tools"]) {
+      const result = checkExactImportSource({
+        expected: "@vendor/*",
+        context: createMockContext({ path: "src/index.ts" }),
+        fileStructure: parseSource({
+          source: `import { value } from '${source}';`,
+        }),
+      });
+      expect(result).toEqual([]);
+    }
+  });
+
   it("does not match package roots with a trailing wildcard", () => {
     const result = checkExactImportSource({
       expected: "package/*",
@@ -223,6 +236,90 @@ describe("checkExactImportSource", () => {
     expect(result).toEqual([]);
   });
 
+  it("resolves template placeholders in selector exclusions", () => {
+    const result = checkExactImportSource({
+      expected: [
+        "@${vendor}/*",
+        "!@${vendor}/harness/*",
+        "@${vendor}/harness/bridge",
+      ],
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { vendor: { toString: () => "ai-sdk" } },
+      }),
+      fileStructure: parseSource({
+        source: "import { bridge } from '@ai-sdk/harness/bridge';",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("accepts selected imports and rejects excluded imports", () => {
+    const expected = [
+      "@ai-sdk/*",
+      "!@ai-sdk/harness",
+      "!@ai-sdk/harness/*",
+      "@ai-sdk/harness/bridge",
+    ];
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkExactImportSource({
+        expected,
+        context,
+        fileStructure: parseSource({
+          source: "import { generate } from '@ai-sdk/core';",
+        }),
+      })
+    ).toEqual([]);
+    expect(
+      checkExactImportSource({
+        expected,
+        context,
+        fileStructure: parseSource({
+          source: "import { harness } from '@ai-sdk/harness';",
+        }),
+      }).map((diagnostic) => diagnostic.message)
+    ).toEqual(['Missing import from "@ai-sdk/*"']);
+    expect(
+      checkExactImportSource({
+        expected,
+        context,
+        fileStructure: parseSource({
+          source: "import { bridge } from '@ai-sdk/harness/bridge';",
+        }),
+      })
+    ).toEqual([]);
+  });
+
+  it("applies selectors only to imports of the requested kind", () => {
+    const expected = ["@vendor/*", "!@vendor/excluded"];
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkExactImportSource({
+        expected,
+        importKind: "type",
+        predicateName: "importTypesFrom",
+        context,
+        fileStructure: parseSource({
+          source: "import type { Tool } from '@vendor/project';",
+        }),
+      })
+    ).toEqual([]);
+    expect(
+      checkExactImportSource({
+        expected,
+        importKind: "type",
+        predicateName: "importTypesFrom",
+        context,
+        fileStructure: parseSource({
+          source: "import { tool } from '@vendor/project';",
+        }),
+      }).map((diagnostic) => diagnostic.message)
+    ).toEqual(['Missing type import from "@vendor/*"']);
+  });
+
   it("requires every import source in an array", () => {
     const result = checkExactImportSource({
       expected: ["react", "package/*"],
@@ -249,6 +346,24 @@ describe("checkExactImportSource", () => {
     expect(result.map((d) => d.message)).toEqual([
       'Missing import from "react"',
       'Missing import from "package"',
+    ]);
+  });
+
+  it("keeps exact entries and a wildcard selector as MUST-ALL constraints", () => {
+    const result = checkExactImportSource({
+      expected: ["react", "zod", "@ai-sdk/*", "!@ai-sdk/harness"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: [
+          "import React from 'react';",
+          "import { harness } from '@ai-sdk/harness';",
+        ].join("\n"),
+      }),
+    });
+
+    expect(result.map((diagnostic) => diagnostic.message)).toEqual([
+      'Missing import from "zod"',
+      'Missing import from "@ai-sdk/*"',
     ]);
   });
 

--- a/packages/konsistent/src/typescript/predicates/import-source-exact.ts
+++ b/packages/konsistent/src/typescript/predicates/import-source-exact.ts
@@ -1,3 +1,7 @@
+import {
+  compileImportSourceConstraints,
+  doesImportSourceConstraintMatch,
+} from "@konsistent/convention";
 import type { PredicateContext } from "../../core/context.js";
 import type { Diagnostic, DiagnosticSeverity } from "../../core/diagnostics.js";
 import { createDiagnostic } from "../../core/diagnostics.js";
@@ -21,6 +25,7 @@ export function checkExactImportSource(opts: {
   expected: string | string[];
   importKind?: ExactImportSourceKind;
   predicateName?: string;
+  selectorSyntax?: boolean;
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -30,23 +35,69 @@ export function checkExactImportSource(opts: {
     expected,
     importKind = "value",
     predicateName = "importValuesFrom",
+    selectorSyntax = true,
     context,
     fileStructure,
     conventionName,
     severity,
   } = opts;
   const diagnostics: Diagnostic[] = [];
-  const expectedSources = typeof expected === "string" ? [expected] : expected;
+  const resolvedExpected =
+    typeof expected === "string"
+      ? resolveConfiguredSource({ source: expected, context, selectorSyntax })
+      : expected.map((source) =>
+          resolveConfiguredSource({ source, context, selectorSyntax })
+        );
+
+  if (selectorSyntax) {
+    const compiled = compileImportSourceConstraints({
+      expected: resolvedExpected,
+    });
+    if (!compiled.success) {
+      throw new Error(compiled.error);
+    }
+
+    for (const constraint of compiled.constraints) {
+      const found = fileStructure.importSources.find(
+        (importSource) =>
+          (importKind === "either" ||
+            importSource.isType === (importKind === "type")) &&
+          doesImportSourceConstraintMatch({
+            source: importSource.from,
+            constraint,
+          })
+      );
+
+      if (found) {
+        continue;
+      }
+
+      diagnostics.push(
+        createDiagnostic({
+          filePath: context.path,
+          predicateName,
+          message: `Missing ${importKind === "type" ? "type import" : "import"} from "${constraint.source}"`,
+          conventionName,
+          severity,
+        })
+      );
+    }
+    return diagnostics;
+  }
+
+  const expectedSources =
+    typeof resolvedExpected === "string"
+      ? [resolvedExpected]
+      : resolvedExpected;
 
   for (const source of expectedSources) {
-    const resolvedFrom = context.resolveTemplate(source);
     const found = fileStructure.importSources.find(
       (importSource) =>
         (importKind === "either" ||
           importSource.isType === (importKind === "type")) &&
         doesImportSourceMatch({
           from: importSource.from,
-          expected: resolvedFrom,
+          expected: source,
         })
     );
 
@@ -58,7 +109,7 @@ export function checkExactImportSource(opts: {
       createDiagnostic({
         filePath: context.path,
         predicateName,
-        message: `Missing ${importKind === "type" ? "type import" : "import"} from "${resolvedFrom}"`,
+        message: `Missing ${importKind === "type" ? "type import" : "import"} from "${source}"`,
         conventionName,
         severity,
       })
@@ -66,4 +117,15 @@ export function checkExactImportSource(opts: {
   }
 
   return diagnostics;
+}
+
+function resolveConfiguredSource(opts: {
+  source: string;
+  context: PredicateContext;
+  selectorSyntax: boolean;
+}): string {
+  if (opts.selectorSyntax && opts.source.startsWith("!")) {
+    return `!${opts.context.resolveTemplate(opts.source.slice(1))}`;
+  }
+  return opts.context.resolveTemplate(opts.source);
 }


### PR DESCRIPTION
## Pull Request Description

Adds nested source selectors to `importValuesFrom` and `importTypesFrom` while preserving MUST-ALL behavior for independent import sources.

- Supports vendor-wide and package-entrypoint `/*` selectors.
- Adds ordered exclusions and nested re-inclusions for `must` and `mustNot`.
- Rejects dangling, unrelated, redundant, and overlapping selector patterns.
- Adds comprehensive unit and e2e coverage for value and type imports.

## Relevant technical choices

Import source arrays are compiled into independent exact constraints and hierarchical wildcard selectors. `mustNot` keeps each selector grouped during inversion, while deprecated `importFrom` retains its existing behavior.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
