### PR TITLE
feat(konsistent): support requiring aliases for value and type imports and exports

### DIFF
--- a/.changeset/whole-ideas-punch.md
+++ b/.changeset/whole-ideas-punch.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): support requiring aliases for value and type imports and exports

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -193,17 +193,33 @@ Assert named value exports — anything that is not syntactically type-only. Fun
 ```json
 "must": {
   "exportValues": [
-    { "name": "${providerId}", "from": "./${providerId}-provider" }
+    {
+      "name": "createProvider",
+      "alias": "create${providerId.toPascalCase()}Provider",
+      "from": "./${providerId}-provider"
+    }
   ]
 }
 ```
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | string | The export name. Templates allowed. |
+| `name` | string | The original local or re-exported name. Templates allowed. |
+| `alias` | string | Optional. Require a named export to expose the symbol under this name. Templates allowed. |
 | `from` | string | Optional. If set, the export must come from a re-export pointing at this module specifier. |
 
-When `from` is omitted, only the export's existence is checked. When `from` is set, the export must be a re-export from that source — useful for enforcing barrel-file structure.
+When `alias` is omitted, the public export name is ignored. For example,
+`{ "name": "createProvider" }` matches both `export { createProvider }` and
+`export { createProvider as createOpenAIProvider }`. When `from` is omitted,
+only the export's existence is checked. When `from` is set, the export must be
+a re-export from that source — useful for enforcing barrel-file structure.
+
+Aliases apply only to non-default named export specifiers. Direct export
+declarations, default exports, namespace exports, and star exports cannot
+satisfy an entry containing `alias`.
+
+In `mustNot`, an entry with `alias` forbids only that exact original/public-name
+pair. Omitting `alias` forbids the original name under every named export alias.
 
 ### `exportTypes`
 
@@ -222,6 +238,7 @@ exported type.
   "exportTypes": [
     {
       "name": "${providerId.toPascalCase()}Provider",
+      "alias": "Provider",
       "from": "./${providerId}-provider"
     }
   ]
@@ -247,13 +264,17 @@ exported type.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | string | The type name. Templates allowed. |
+| `name` | string | The original local or re-exported type name. Templates allowed. |
+| `alias` | string | Optional. Require a named type export to expose the type under this name. Templates allowed. |
 | `from` | string | Optional. Require a type re-export from this module specifier. |
 | `schema` | object | Optional. Validate a locally declared type definition. |
 
 `from` and `schema` are mutually exclusive. Schema validation never resolves a
 type definition from another file. The `schema` field supports the same forms
 and declaration semantics documented under [`exportConstants`](#exportconstants).
+When `alias` is combined with `schema`, the schema validates the original local
+type definition. Alias omission and unsupported export forms behave as
+documented for `exportValues`.
 
 ### `exportConstants`
 
@@ -401,17 +422,28 @@ Assert named value imports.
 ```json
 "must": {
   "importValues": [
-    { "name": "useState", "from": "react" }
+    { "name": "createClient", "alias": "createApiClient", "from": "api" }
   ]
 }
 ```
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | string | The imported binding. Templates allowed. |
+| `name` | string | The original imported name. Templates allowed. |
+| `alias` | string | Optional. Require the named import to use this local binding. Templates allowed. |
 | `from` | string | Optional. Module specifier the import must come from. |
 
-Bare-string form (`"importValues": ["useState"]`) checks the binding regardless of source.
+When `alias` is omitted, the local binding is ignored. For example,
+`{ "name": "createClient" }` matches both `import { createClient }` and
+`import { createClient as createApiClient }`. The bare-string form is the same
+alias-insensitive check without a source constraint.
+
+Aliases apply only to non-default named import specifiers. Default and namespace
+imports cannot satisfy an entry containing `alias`; without `alias`, their
+existing local-binding behavior is unchanged.
+
+In `mustNot`, an entry with `alias` forbids only that exact original/local-name
+pair. Omitting `alias` forbids the original name under every named import alias.
 
 ### `importValuesFrom`
 

--- a/e2e/fixtures/symbol-aliases-broken/konsistent.json
+++ b/e2e/fixtures/symbol-aliases-broken/konsistent.json
@@ -1,0 +1,41 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "broken-symbol-aliases",
+      "paths": "src/index.ts",
+      "must": {
+        "importValues": [
+          { "name": "createClient", "alias": "createApiClient", "from": "client-package" }
+        ],
+        "importTypes": [
+          { "name": "ClientConfig", "alias": "ApiClientConfig", "from": "client-types" }
+        ],
+        "exportValues": [
+          { "name": "createProvider", "alias": "createApiProvider" }
+        ],
+        "exportTypes": [
+          { "name": "LocalSettings", "alias": "PublicSettings" }
+        ]
+      },
+      "mustNot": {
+        "importValues": [
+          { "name": "blockedImport", "alias": "forbiddenLocalImport" },
+          "anyAliasImport"
+        ],
+        "importTypes": [
+          { "name": "BlockedType", "alias": "ForbiddenLocalType" },
+          "AnyAliasType"
+        ],
+        "exportValues": [
+          { "name": "blockedExport", "alias": "forbiddenPublicExport" },
+          "anyAliasExport"
+        ],
+        "exportTypes": [
+          { "name": "BlockedExportType", "alias": "ForbiddenPublicType" },
+          "AnyAliasExportType"
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/symbol-aliases-broken/src/index.ts
+++ b/e2e/fixtures/symbol-aliases-broken/src/index.ts
@@ -1,0 +1,31 @@
+import {
+  anyAliasImport as renamedAnyAliasImport,
+  blockedImport as forbiddenLocalImport,
+  createClient as wrongClientAlias,
+} from "client-package";
+import type {
+  AnyAliasType as RenamedAnyAliasType,
+  BlockedType as ForbiddenLocalType,
+  ClientConfig as WrongConfigAlias,
+} from "client-types";
+
+const createProvider = () => ({
+  renamedAnyAliasImport,
+  wrongClientAlias,
+});
+type LocalSettings = {
+  enabled?: boolean;
+};
+const anyAliasExport = true;
+type AnyAliasExportType = string;
+
+export { createProvider as wrongProviderAlias };
+export type { LocalSettings as WrongSettingsAlias };
+export { anyAliasExport as renamedAnyAliasExport };
+export type { AnyAliasExportType as RenamedAnyAliasExportType };
+export { blockedExport as forbiddenPublicExport } from "./remote-values";
+export type {
+  BlockedExportType as ForbiddenPublicType,
+} from "./remote-types";
+
+export type FixtureTypes = RenamedAnyAliasType | ForbiddenLocalType;

--- a/e2e/fixtures/symbol-aliases/konsistent.json
+++ b/e2e/fixtures/symbol-aliases/konsistent.json
@@ -1,0 +1,50 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "symbol-aliases",
+      "paths": "src/index.ts",
+      "must": {
+        "importValues": [
+          { "name": "createClient", "alias": "createApiClient", "from": "client-package" },
+          { "name": "parseInput", "from": "client-package" }
+        ],
+        "importTypes": [
+          { "name": "ClientConfig", "alias": "ApiClientConfig", "from": "client-types" },
+          { "name": "LooseType", "from": "client-types" }
+        ],
+        "exportValues": [
+          { "name": "createProvider", "alias": "createApiProvider" },
+          { "name": "remoteValue", "alias": "publicRemoteValue", "from": "./remote-values" },
+          { "name": "looseValue", "from": "./remote-values" }
+        ],
+        "exportTypes": [
+          {
+            "name": "LocalSettings",
+            "alias": "PublicSettings",
+            "schema": {
+              "type": "object",
+              "properties": { "enabled": { "type": "boolean" } }
+            }
+          },
+          { "name": "RemoteType", "alias": "PublicRemoteType", "from": "./remote-types" },
+          { "name": "LooseRemoteType", "from": "./remote-types" }
+        ]
+      },
+      "mustNot": {
+        "importValues": [
+          { "name": "blockedImport", "alias": "forbiddenLocalImport" }
+        ],
+        "importTypes": [
+          { "name": "BlockedType", "alias": "ForbiddenLocalType" }
+        ],
+        "exportValues": [
+          { "name": "blockedExport", "alias": "forbiddenPublicExport" }
+        ],
+        "exportTypes": [
+          { "name": "BlockedExportType", "alias": "ForbiddenPublicType" }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/symbol-aliases/src/index.ts
+++ b/e2e/fixtures/symbol-aliases/src/index.ts
@@ -1,0 +1,33 @@
+import {
+  blockedImport as allowedLocalImport,
+  createClient as createApiClient,
+  parseInput as renamedParser,
+} from "client-package";
+import type {
+  BlockedType as AllowedLocalType,
+  ClientConfig as ApiClientConfig,
+  LooseType as RenamedLooseType,
+} from "client-types";
+
+const createProvider = () => ({
+  createApiClient,
+  renamedParser,
+});
+type LocalSettings = {
+  enabled?: boolean;
+};
+
+export { createProvider as createApiProvider };
+export type { LocalSettings as PublicSettings };
+export {
+  blockedExport as allowedPublicExport,
+  looseValue as renamedLooseValue,
+  remoteValue as publicRemoteValue,
+} from "./remote-values";
+export type {
+  BlockedExportType as AllowedPublicType,
+  LooseRemoteType as RenamedLooseRemoteType,
+  RemoteType as PublicRemoteType,
+} from "./remote-types";
+
+export type FixtureTypes = ApiClientConfig | RenamedLooseType | AllowedLocalType;

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -247,3 +247,55 @@ describe("import-source-selectors-invalid fixture", () => {
     }
   });
 });
+
+describe("symbol-aliases fixture", () => {
+  const cwd = resolve(fixturesDir, "symbol-aliases");
+
+  it("passes aliases and alias-insensitive checks in must and mustNot", async () => {
+    await expect(runCli({ cwd })).resolves.not.toThrow();
+  });
+});
+
+describe("symbol-aliases-broken fixture", () => {
+  const cwd = resolve(fixturesDir, "symbol-aliases-broken");
+
+  it("fails incorrect and forbidden value and type aliases", async () => {
+    try {
+      await runCli({ cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as { stdout: string; code: number; status: number };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain(
+        'Missing import "createClient" as "createApiClient"'
+      );
+      expect(error.stdout).toContain(
+        'Missing import type "ClientConfig" as "ApiClientConfig"'
+      );
+      expect(error.stdout).toContain(
+        'Missing export "createProvider" as "createApiProvider"'
+      );
+      expect(error.stdout).toContain(
+        'Missing export type "LocalSettings" as "PublicSettings"'
+      );
+      expect(error.stdout).toContain(
+        'Forbidden import "blockedImport" as "forbiddenLocalImport"'
+      );
+      expect(error.stdout).toContain('Forbidden import "anyAliasImport"');
+      expect(error.stdout).toContain(
+        'Forbidden type import "BlockedType" as "ForbiddenLocalType"'
+      );
+      expect(error.stdout).toContain('Forbidden type import "AnyAliasType"');
+      expect(error.stdout).toContain(
+        'Forbidden export "blockedExport" as "forbiddenPublicExport"'
+      );
+      expect(error.stdout).toContain('Forbidden export "anyAliasExport"');
+      expect(error.stdout).toContain(
+        'Forbidden type export "BlockedExportType" as "ForbiddenPublicType"'
+      );
+      expect(error.stdout).toContain(
+        'Forbidden type export "AnyAliasExportType"'
+      );
+    }
+  });
+});

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -553,6 +553,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -603,6 +606,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -747,6 +753,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -1064,6 +1073,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1153,6 +1165,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1677,6 +1692,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1727,6 +1745,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -1871,6 +1892,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -2188,6 +2212,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -2277,6 +2304,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -2882,6 +2912,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -2932,6 +2965,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -3076,6 +3112,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -3393,6 +3432,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -3482,6 +3524,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -4006,6 +4051,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -4056,6 +4104,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -4200,6 +4251,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -4517,6 +4571,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -4606,6 +4663,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },

--- a/packages/convention/src/constant-schema.test.ts
+++ b/packages/convention/src/constant-schema.test.ts
@@ -69,8 +69,15 @@ describe("type definition schemas", () => {
 
   it.each([
     { name: "Settings" },
+    { name: "Settings", alias: "PublicSettings" },
     { name: "Settings", from: "./settings" },
+    { name: "Settings", alias: "PublicSettings", from: "./settings" },
     { name: "Settings", schema: { type: "object", properties: {} } },
+    {
+      name: "Settings",
+      alias: "PublicSettings",
+      schema: { type: "object", properties: {} },
+    },
   ])("accepts exported type definition %#", (definition) => {
     expect(ExportTypeDefinitionV1Schema.safeParse(definition).success).toBe(
       true
@@ -81,6 +88,7 @@ describe("type definition schemas", () => {
     expect(
       ExportTypeDefinitionV1Schema.safeParse({
         name: "Settings",
+        alias: "PublicSettings",
         from: "./settings",
         schema: { type: "object", properties: {} },
       }).success

--- a/packages/convention/src/constant-schema.ts
+++ b/packages/convention/src/constant-schema.ts
@@ -112,8 +112,13 @@ export const TypeDefinitionV1Schema = z.strictObject({
 });
 
 export const ExportTypeDefinitionV1Schema = z.union([
-  TypeDefinitionV1Schema,
   z.strictObject({
+    alias: z.string().optional(),
+    name: z.string(),
+    schema: ConstantValueSchemaV1Schema.optional(),
+  }),
+  z.strictObject({
+    alias: z.string().optional(),
     name: z.string(),
     from: z.string(),
   }),

--- a/packages/convention/src/generated-schema.test.ts
+++ b/packages/convention/src/generated-schema.test.ts
@@ -82,6 +82,44 @@ describe("reusable-convention-package.schema.json", () => {
     expect(valid).toBe(true);
   });
 
+  it("accepts aliases for current value and type symbol predicates", () => {
+    const valid = validate({
+      conventionSpecVersion: "v1",
+      conventions: [
+        {
+          name: "aliases",
+          description: "Symbol aliases.",
+          must: {
+            importValues: [{ name: "sourceValue", alias: "localValue" }],
+            importTypes: [{ name: "SourceType", alias: "LocalType" }],
+            exportValues: [{ name: "localValue", alias: "publicValue" }],
+            exportTypes: [{ name: "LocalType", alias: "PublicType" }],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(true);
+  });
+
+  it.each([
+    "import",
+    "export",
+  ])("rejects aliases for the deprecated %s predicate", (predicate) => {
+    const valid = validate({
+      conventionSpecVersion: "v1",
+      conventions: [
+        {
+          name: "legacy",
+          description: "Legacy predicate.",
+          must: {
+            [predicate]: [{ name: "source", alias: "publicName" }],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(false);
+  });
+
   it("rejects exportTypes entries with both from and schema", () => {
     const valid = validate({
       conventionSpecVersion: "v1",

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -8,6 +8,7 @@ import {
 import { compileImportSourceConstraints } from "./import-source-selector.js";
 
 export const ExportDefinitionV1Schema = z.strictObject({
+  alias: z.string().optional(),
   name: z.string(),
   from: z.string().optional(),
 });
@@ -17,6 +18,17 @@ export const DeclarationDefinitionV1Schema = z.strictObject({
 });
 
 export const ImportDefinitionV1Schema = z.strictObject({
+  alias: z.string().optional(),
+  name: z.string(),
+  from: z.string().optional(),
+});
+
+const LegacyExportDefinitionV1Schema = z.strictObject({
+  name: z.string(),
+  from: z.string().optional(),
+});
+
+const LegacyImportDefinitionV1Schema = z.strictObject({
   name: z.string(),
   from: z.string().optional(),
 });
@@ -55,6 +67,12 @@ const ExportValuesPredicateV1Schema = z.array(
 );
 const ImportValuesPredicateV1Schema = z.array(
   z.union([z.string(), ImportDefinitionV1Schema])
+);
+const LegacyExportPredicateV1Schema = z.array(
+  z.union([z.string(), LegacyExportDefinitionV1Schema])
+);
+const LegacyImportPredicateV1Schema = z.array(
+  z.union([z.string(), LegacyImportDefinitionV1Schema])
 );
 const ExactImportSourcePredicateV1Schema = z.union([
   z.string(),
@@ -95,7 +113,7 @@ export const MustPredicatesV1Schema = z.strictObject({
   /**
    * @deprecated Use exportValues instead.
    */
-  export: ExportValuesPredicateV1Schema.optional().meta({
+  export: LegacyExportPredicateV1Schema.optional().meta({
     deprecated: true,
     description: "Use exportValues instead.",
   }),
@@ -118,7 +136,7 @@ export const MustPredicatesV1Schema = z.strictObject({
   /**
    * @deprecated Use importValues instead.
    */
-  import: ImportValuesPredicateV1Schema.optional().meta({
+  import: LegacyImportPredicateV1Schema.optional().meta({
     deprecated: true,
     description: "Use importValues instead.",
   }),

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -654,6 +654,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -708,6 +711,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -869,6 +875,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -1218,6 +1227,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1311,6 +1323,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1886,6 +1901,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -1940,6 +1958,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -2101,6 +2122,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -2450,6 +2474,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -2543,6 +2570,9 @@
                         {
                           "type": "object",
                           "properties": {
+                            "alias": {
+                              "type": "string"
+                            },
                             "name": {
                               "type": "string"
                             },
@@ -3176,6 +3206,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -3230,6 +3263,9 @@
                                     {
                                       "type": "object",
                                       "properties": {
+                                        "alias": {
+                                          "type": "string"
+                                        },
                                         "name": {
                                           "type": "string"
                                         },
@@ -3391,6 +3427,9 @@
                                     {
                                       "type": "object",
                                       "properties": {
+                                        "alias": {
+                                          "type": "string"
+                                        },
                                         "name": {
                                           "type": "string"
                                         },
@@ -3740,6 +3779,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -3833,6 +3875,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -4484,6 +4529,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -4538,6 +4586,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -4699,6 +4750,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -5048,6 +5102,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -5141,6 +5198,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -5716,6 +5776,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -5770,6 +5833,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -5931,6 +5997,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -6280,6 +6349,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -6373,6 +6445,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -7020,6 +7095,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -7074,6 +7152,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -7235,6 +7316,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -7584,6 +7668,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -7677,6 +7764,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -8252,6 +8342,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -8306,6 +8399,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -8467,6 +8563,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -8816,6 +8915,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -8909,6 +9011,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -9562,6 +9667,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -9616,6 +9724,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -9777,6 +9888,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -10126,6 +10240,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -10219,6 +10336,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -10794,6 +10914,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -10848,6 +10971,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -11009,6 +11135,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -11358,6 +11487,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -11451,6 +11583,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -12037,6 +12172,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -12091,6 +12229,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -12252,6 +12393,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -12601,6 +12745,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -12694,6 +12841,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -13326,6 +13476,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -13380,6 +13533,9 @@
                                     {
                                       "type": "object",
                                       "properties": {
+                                        "alias": {
+                                          "type": "string"
+                                        },
                                         "name": {
                                           "type": "string"
                                         },
@@ -13541,6 +13697,9 @@
                                     {
                                       "type": "object",
                                       "properties": {
+                                        "alias": {
+                                          "type": "string"
+                                        },
                                         "name": {
                                           "type": "string"
                                         },
@@ -13890,6 +14049,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -13983,6 +14145,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -14634,6 +14799,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -14688,6 +14856,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -14849,6 +15020,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -15198,6 +15372,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -15291,6 +15468,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -15866,6 +16046,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -15920,6 +16103,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -16081,6 +16267,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -16430,6 +16619,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -16523,6 +16715,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -17170,6 +17365,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -17224,6 +17422,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -17385,6 +17586,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -17734,6 +17938,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -17827,6 +18034,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -18402,6 +18612,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -18456,6 +18669,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -18617,6 +18833,9 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
+                                                      "alias": {
+                                                        "type": "string"
+                                                      },
                                                       "name": {
                                                         "type": "string"
                                                       },
@@ -18966,6 +19185,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -19059,6 +19281,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -19712,6 +19937,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -19766,6 +19994,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -19927,6 +20158,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -20276,6 +20510,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -20369,6 +20606,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -20944,6 +21184,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -20998,6 +21241,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -21159,6 +21405,9 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
+                                                  "alias": {
+                                                    "type": "string"
+                                                  },
                                                   "name": {
                                                     "type": "string"
                                                   },
@@ -21508,6 +21757,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -21601,6 +21853,9 @@
                                           {
                                             "type": "object",
                                             "properties": {
+                                              "alias": {
+                                                "type": "string"
+                                              },
                                               "name": {
                                                 "type": "string"
                                               },
@@ -22187,6 +22442,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -22241,6 +22499,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -22402,6 +22663,9 @@
                                 {
                                   "type": "object",
                                   "properties": {
+                                    "alias": {
+                                      "type": "string"
+                                    },
                                     "name": {
                                       "type": "string"
                                     },
@@ -22751,6 +23015,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },
@@ -22844,6 +23111,9 @@
                             {
                               "type": "object",
                               "properties": {
+                                "alias": {
+                                  "type": "string"
+                                },
                                 "name": {
                                   "type": "string"
                                 },

--- a/packages/konsistent/src/config/placeholder-validator.test.ts
+++ b/packages/konsistent/src/config/placeholder-validator.test.ts
@@ -108,6 +108,34 @@ describe("validatePlaceholders", () => {
     }
   });
 
+  it("detects placeholders inside import and export aliases", () => {
+    const conventions: ConventionV1[] = [
+      {
+        name: "aliases",
+        paths: ["src/{x}"],
+        must: {
+          importValues: [{ name: "sourceValue", alias: "${missingImport}" }],
+          importTypes: [{ name: "SourceType", alias: "${missingTypeImport}" }],
+          exportValues: [{ name: "sourceValue", alias: "${missingExport}" }],
+          exportTypes: [{ name: "SourceType", alias: "${missingTypeExport}" }],
+        },
+      },
+    ];
+
+    const result = validatePlaceholders({
+      conventions,
+      identifiers: ["aliases"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('"${missingImport}"');
+      expect(result.error).toContain('"${missingTypeImport}"');
+      expect(result.error).toContain('"${missingExport}"');
+      expect(result.error).toContain('"${missingTypeExport}"');
+    }
+  });
+
   it("detects a placeholder inside a nested MustBlock predicate", () => {
     const conventions: ConventionV1[] = [
       {

--- a/packages/konsistent/src/config/placeholder-validator.ts
+++ b/packages/konsistent/src/config/placeholder-validator.ts
@@ -259,7 +259,7 @@ function collectUsagesInPredicates(opts: {
   collectUsagesInDefinitionList({
     list: predicates.exportValues,
     key: `${prefix}.exportValues`,
-    objectFields: ["name", "from"],
+    objectFields: ["name", "alias", "from"],
     declared,
     usages,
   });
@@ -273,7 +273,7 @@ function collectUsagesInPredicates(opts: {
   collectUsagesInDefinitionList({
     list: predicates.exportTypes,
     key: `${prefix}.exportTypes`,
-    objectFields: ["name", "from"],
+    objectFields: ["name", "alias", "from"],
     declared,
     usages,
   });
@@ -312,7 +312,7 @@ function collectUsagesInPredicates(opts: {
   collectUsagesInDefinitionList({
     list: predicates.importValues,
     key: `${prefix}.importValues`,
-    objectFields: ["name", "from"],
+    objectFields: ["name", "alias", "from"],
     declared,
     usages,
   });
@@ -344,7 +344,7 @@ function collectUsagesInPredicates(opts: {
   collectUsagesInDefinitionList({
     list: predicates.importTypes,
     key: `${prefix}.importTypes`,
-    objectFields: ["name", "from"],
+    objectFields: ["name", "alias", "from"],
     declared,
     usages,
   });

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -146,6 +146,68 @@ describe("ConfigV1Schema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts aliases for value and type import and export predicates", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            importValues: [{ name: "sourceValue", alias: "localValue" }],
+            importTypes: [{ name: "SourceType", alias: "LocalType" }],
+            exportValues: [{ name: "localValue", alias: "publicValue" }],
+            exportTypes: [
+              {
+                name: "LocalType",
+                alias: "PublicType",
+                schema: { type: "object", properties: {} },
+              },
+              {
+                name: "RemoteType",
+                alias: "PublicRemoteType",
+                from: "./types",
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    "import",
+    "export",
+  ])("rejects aliases for the deprecated %s predicate", (predicate) => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            [predicate]: [{ name: "source", alias: "publicName" }],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects aliases for specialized export predicates", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          must: {
+            exportConstants: [{ name: "source", alias: "publicName" }],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts conventions with declaration order and import source predicates", () => {
     const result = ConfigV1Schema.safeParse({
       version: "v1",

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -203,6 +203,126 @@ describe("run", () => {
     expect(diagnostics[0].message).toBe('Forbidden constant export "debug"');
   });
 
+  it("forbids exact import and export alias pairs", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importValues: [{ name: "sourceValue", alias: "localValue" }],
+            importTypes: [{ name: "SourceType", alias: "LocalType" }],
+            exportValues: [{ name: "sourceExport", alias: "publicValue" }],
+            exportTypes: [{ name: "SourceExportType", alias: "PublicType" }],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            'import { sourceValue as localValue } from "pkg";',
+            'import type { SourceType as LocalType } from "types";',
+            "const sourceExport = 1;",
+            "type SourceExportType = string;",
+            "export { sourceExport as publicValue };",
+            "export type { SourceExportType as PublicType };",
+          ].join("\n"),
+        ],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      'Forbidden import "sourceValue" as "localValue"',
+      'Forbidden type import "SourceType" as "LocalType"',
+      'Forbidden export "sourceExport" as "publicValue"',
+      'Forbidden type export "SourceExportType" as "PublicType"',
+    ]);
+  });
+
+  it("allows a different alias when mustNot configures an exact pair", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importValues: [{ name: "sourceValue", alias: "blockedValue" }],
+            importTypes: [{ name: "SourceType", alias: "BlockedType" }],
+            exportValues: [{ name: "sourceExport", alias: "blockedExport" }],
+            exportTypes: [
+              { name: "SourceExportType", alias: "BlockedExportType" },
+            ],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            'import { sourceValue as allowedValue } from "pkg";',
+            'import type { SourceType as AllowedType } from "types";',
+            "const sourceExport = 1;",
+            "type SourceExportType = string;",
+            "export { sourceExport as allowedExport };",
+            "export type { SourceExportType as AllowedExportType };",
+          ].join("\n"),
+        ],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("forbids original names under any named alias when alias is omitted", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/module.ts",
+          mustNot: {
+            importValues: ["sourceValue"],
+            importTypes: ["SourceType"],
+            exportValues: ["sourceExport"],
+            exportTypes: ["SourceExportType"],
+          },
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module.ts", ["src/module.ts"]]]),
+      files: new Set(["src/module.ts"]),
+      fileContents: new Map([
+        [
+          "src/module.ts",
+          [
+            'import { sourceValue as localValue } from "pkg";',
+            'import type { SourceType as LocalType } from "types";',
+            "const sourceExport = 1;",
+            "type SourceExportType = string;",
+            "export { sourceExport as publicValue };",
+            "export type { SourceExportType as PublicType };",
+          ].join("\n"),
+        ],
+      ]),
+    });
+    const { diagnostics } = await run({ config, fileSystem: fs });
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      'Forbidden import "sourceValue"',
+      'Forbidden type import "SourceType"',
+      'Forbidden export "sourceExport"',
+      'Forbidden type export "SourceExportType"',
+    ]);
+  });
+
   it("forbids a constant matching a mustNot schema", async () => {
     const config: ConfigV1 = {
       version: "v1",

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -787,6 +787,22 @@ function resolveEntryName(opts: {
   return "unknown";
 }
 
+function resolveEntryAlias(opts: {
+  value: unknown;
+  context: PredicateContext;
+}): string | undefined {
+  const { value, context } = opts;
+  if (
+    value &&
+    typeof value === "object" &&
+    Object.hasOwn(value, "alias") &&
+    typeof (value as { alias: unknown }).alias === "string"
+  ) {
+    return context.resolveTemplate((value as { alias: string }).alias);
+  }
+  return;
+}
+
 function formatForbiddenMessage(opts: {
   key: string;
   value: unknown;
@@ -794,6 +810,8 @@ function formatForbiddenMessage(opts: {
 }): string {
   const { key, value, context } = opts;
   const name = resolveEntryName({ value, context });
+  const alias = resolveEntryAlias({ value, context });
+  const aliasSuffix = alias === undefined ? "" : ` as "${alias}"`;
 
   switch (key) {
     case "haveType":
@@ -812,9 +830,9 @@ function formatForbiddenMessage(opts: {
       return `Forbidden class declaration "${name}"`;
     case "exportValues":
     case "export":
-      return `Forbidden export "${name}"`;
+      return `Forbidden export "${name}"${aliasSuffix}`;
     case "exportTypes":
-      return `Forbidden type export "${name}"`;
+      return `Forbidden type export "${name}"${aliasSuffix}`;
     case "exportConstants":
       return `Forbidden constant export "${name}"`;
     case "exportFunctions":
@@ -825,14 +843,14 @@ function formatForbiddenMessage(opts: {
       return `Forbidden class export "${name}"`;
     case "importValues":
     case "import":
-      return `Forbidden import "${name}"`;
+      return `Forbidden import "${name}"${aliasSuffix}`;
     case "importValuesFrom":
     case "importFrom":
       return `Forbidden import from "${context.resolveTemplate(String(value))}"`;
     case "importTypesFrom":
       return `Forbidden type import from "${context.resolveTemplate(String(value))}"`;
     case "importTypes":
-      return `Forbidden type import "${name}"`;
+      return `Forbidden type import "${name}"${aliasSuffix}`;
     case "importValuesFromCurrentDir":
     case "importFromCurrentDir":
       return value === false

--- a/packages/konsistent/src/typescript/parser.test.ts
+++ b/packages/konsistent/src/typescript/parser.test.ts
@@ -168,15 +168,40 @@ describe("parseFileStructure", () => {
       });
       expect(result.imports).toHaveLength(2);
       expect(result.imports[0]).toMatchObject({
+        kind: "named",
         name: "foo",
+        sourceName: "foo",
         from: "module",
         isType: false,
       });
       expect(result.imports[1]).toMatchObject({
+        kind: "named",
         name: "bar",
+        sourceName: "bar",
         from: "module",
         isType: false,
       });
+    });
+
+    it("extracts original and local names from aliased named imports", () => {
+      const result = parseFileStructure({
+        source:
+          "import { sourceName as localName, type SourceType as LocalType } from 'module';",
+      });
+      expect(result.imports).toMatchObject([
+        {
+          kind: "named",
+          name: "localName",
+          sourceName: "sourceName",
+          isType: false,
+        },
+        {
+          kind: "named",
+          name: "LocalType",
+          sourceName: "SourceType",
+          isType: true,
+        },
+      ]);
     });
 
     it("extracts type imports", () => {
@@ -212,6 +237,7 @@ describe("parseFileStructure", () => {
       });
       expect(result.imports).toHaveLength(1);
       expect(result.imports[0]).toMatchObject({
+        kind: "namespace",
         name: "ns",
         from: "module",
         isType: false,
@@ -224,6 +250,7 @@ describe("parseFileStructure", () => {
       });
       expect(result.imports).toHaveLength(1);
       expect(result.imports[0]).toMatchObject({
+        kind: "default",
         name: "DefaultExport",
         from: "module",
         isType: false,

--- a/packages/konsistent/src/typescript/parser.ts
+++ b/packages/konsistent/src/typescript/parser.ts
@@ -301,7 +301,11 @@ function processImportDeclaration(opts: {
     if (ts.isNamedImports(node.importClause.namedBindings)) {
       for (const element of node.importClause.namedBindings.elements) {
         collector.imports.push({
+          kind: "named",
           name: element.name.getText(sourceFile),
+          sourceName: (element.propertyName ?? element.name).getText(
+            sourceFile
+          ),
           from: moduleSpecifier,
           isType: isTypeOnly || element.isTypeOnly,
           pos,
@@ -309,6 +313,7 @@ function processImportDeclaration(opts: {
       }
     } else if (ts.isNamespaceImport(node.importClause.namedBindings)) {
       collector.imports.push({
+        kind: "namespace",
         name: node.importClause.namedBindings.name.getText(sourceFile),
         from: moduleSpecifier,
         isType: isTypeOnly,
@@ -319,6 +324,7 @@ function processImportDeclaration(opts: {
 
   if (node.importClause?.name) {
     collector.imports.push({
+      kind: "default",
       name: node.importClause.name.getText(sourceFile),
       from: moduleSpecifier,
       isType: isTypeOnly,

--- a/packages/konsistent/src/typescript/predicates/export-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.test.ts
@@ -226,6 +226,100 @@ describe("checkExportTypes", () => {
     expect(result).toEqual([]);
   });
 
+  it("matches an aliased named type export by its original name", () => {
+    const result = checkExportTypes({
+      expected: ["LocalType"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source:
+          "type LocalType = string; export type { LocalType as PublicType };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("requires an exact alias when configured", () => {
+    const source =
+      "type LocalType = string; export type { LocalType as PublicType };";
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkExportTypes({
+        expected: [{ name: "LocalType", alias: "PublicType" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })
+    ).toEqual([]);
+    expect(
+      checkExportTypes({
+        expected: [{ name: "LocalType", alias: "OtherType" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })[0].message
+    ).toBe('Missing export type "LocalType" as "OtherType"');
+  });
+
+  it("matches an aliased type re-export with a from constraint", () => {
+    const result = checkExportTypes({
+      expected: [{ name: "SourceType", alias: "PublicType", from: "./source" }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'export type { SourceType as PublicType } from "./source";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("resolves template placeholders in aliases", () => {
+    const result = checkExportTypes({
+      expected: [{ name: "LocalType", alias: "Public${name}" }],
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { name: { toString: () => "Type" } },
+      }),
+      fileStructure: parseFileStructure({
+        source:
+          "type LocalType = string; export type { LocalType as PublicType };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("allows an alias equal to the source name for a named type export", () => {
+    const result = checkExportTypes({
+      expected: [{ name: "LocalType", alias: "LocalType" }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: "type LocalType = string; export type { LocalType };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("does not apply aliases to direct or default type exports", () => {
+    const context = createMockContext({ path: "src/index.ts" });
+    const cases = [
+      {
+        source: "export type LocalType = string;",
+        expected: { name: "LocalType", alias: "LocalType" },
+      },
+      {
+        source: 'export type { default as PublicType } from "./source";',
+        expected: { name: "default", alias: "PublicType" },
+      },
+    ];
+
+    for (const entry of cases) {
+      expect(
+        checkExportTypes({
+          expected: [entry.expected],
+          context,
+          fileStructure: parseFileStructure({ source: entry.source }),
+        })
+      ).toHaveLength(1);
+    }
+  });
+
   it("includes conventionName when provided", () => {
     const result = checkExportTypes({
       expected: ["Missing"],
@@ -258,6 +352,29 @@ describe("checkExportTypes", () => {
             timeout?: number;
             reasoning?: "low" | "medium" | "high";
           };
+        `,
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("validates the original local type definition through an export alias", () => {
+    const result = checkExportTypes({
+      expected: [
+        {
+          name: "ModuleSettings",
+          alias: "PublicSettings",
+          schema: {
+            type: "object",
+            properties: { model: { type: "string" } },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: `
+          type ModuleSettings = { model?: string };
+          export type { ModuleSettings as PublicSettings };
         `,
       }),
     });

--- a/packages/konsistent/src/typescript/predicates/export-types.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.ts
@@ -25,22 +25,29 @@ export function checkExportTypes(opts: {
     const resolvedFrom = Object.hasOwn(definition, "from")
       ? context.resolveTemplate((definition as { from: string }).from)
       : undefined;
+    const resolvedAlias =
+      Object.hasOwn(definition, "alias") &&
+      (definition as { alias?: string }).alias !== undefined
+        ? context.resolveTemplate((definition as { alias: string }).alias)
+        : undefined;
 
-    const found = fileStructure.exports.find(
-      (e) =>
-        e.name === resolvedName &&
-        e.isType &&
-        (resolvedFrom === undefined || e.from === resolvedFrom)
-    );
+    const found = findExportedType({
+      fileStructure,
+      name: resolvedName,
+      alias: resolvedAlias,
+      from: resolvedFrom,
+    });
 
     if (!found) {
       diagnostics.push(
         createDiagnostic({
           filePath: context.path,
           predicateName: "exportTypes",
-          message: resolvedFrom
-            ? `Missing export type "${resolvedName}" from "${resolvedFrom}"`
-            : `Missing export type "${resolvedName}"`,
+          message: formatMissingExportMessage({
+            name: resolvedName,
+            alias: resolvedAlias,
+            from: resolvedFrom,
+          }),
           conventionName,
           severity,
         })
@@ -77,4 +84,42 @@ export function checkExportTypes(opts: {
   }
 
   return diagnostics;
+}
+
+function findExportedType(opts: {
+  fileStructure: FileStructure;
+  name: string;
+  alias?: string;
+  from?: string;
+}):
+  | FileStructure["exports"][number]
+  | FileStructure["namedExportSymbols"][number]
+  | undefined {
+  const { fileStructure, name, alias, from } = opts;
+  if (alias === undefined) {
+    return fileStructure.exports.find(
+      (entry) =>
+        entry.name === name &&
+        entry.isType &&
+        (from === undefined || entry.from === from)
+    );
+  }
+  return fileStructure.namedExportSymbols.find(
+    (entry) =>
+      entry.sourceName !== "default" &&
+      entry.sourceName === name &&
+      entry.name === alias &&
+      entry.isType &&
+      (from === undefined || entry.from === from)
+  );
+}
+
+function formatMissingExportMessage(opts: {
+  name: string;
+  alias?: string;
+  from?: string;
+}): string {
+  const alias = opts.alias === undefined ? "" : ` as "${opts.alias}"`;
+  const from = opts.from === undefined ? "" : ` from "${opts.from}"`;
+  return `Missing export type "${opts.name}"${alias}${from}`;
 }

--- a/packages/konsistent/src/typescript/predicates/export-values.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-values.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
 import type { FileStructure } from "../types.js";
 import { checkExportValues } from "./export-values.js";
 
@@ -223,6 +224,104 @@ describe("checkExportValues", () => {
       }),
     });
     expect(result).toEqual([]);
+  });
+
+  it("matches an aliased named export by its original name", () => {
+    const result = checkExportValues({
+      expected: ["localValue"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: "const localValue = 1; export { localValue as publicValue };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("requires an exact alias when configured", () => {
+    const source =
+      "const localValue = 1; export { localValue as publicValue };";
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkExportValues({
+        expected: [{ name: "localValue", alias: "publicValue" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })
+    ).toEqual([]);
+    expect(
+      checkExportValues({
+        expected: [{ name: "localValue", alias: "otherValue" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })[0].message
+    ).toBe('Missing export "localValue" as "otherValue"');
+  });
+
+  it("matches an aliased re-export with a from constraint", () => {
+    const result = checkExportValues({
+      expected: [
+        { name: "sourceValue", alias: "publicValue", from: "./source" },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'export { sourceValue as publicValue } from "./source";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("resolves template placeholders in aliases", () => {
+    const result = checkExportValues({
+      expected: [{ name: "localValue", alias: "public${name}" }],
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { name: { toString: () => "Value" } },
+      }),
+      fileStructure: parseFileStructure({
+        source: "const localValue = 1; export { localValue as publicValue };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("allows an alias equal to the source name for a named export", () => {
+    const result = checkExportValues({
+      expected: [{ name: "localValue", alias: "localValue" }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: "const localValue = 1; export { localValue };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("does not apply aliases to direct, default, or namespace exports", () => {
+    const context = createMockContext({ path: "src/index.ts" });
+    const cases = [
+      {
+        source: "export const localValue = 1;",
+        expected: { name: "localValue", alias: "localValue" },
+      },
+      {
+        source: 'export { default as PublicValue } from "./source";',
+        expected: { name: "default", alias: "PublicValue" },
+      },
+      {
+        source: 'export * as PublicNamespace from "./source";',
+        expected: { name: "*", alias: "PublicNamespace" },
+      },
+    ];
+
+    for (const entry of cases) {
+      expect(
+        checkExportValues({
+          expected: [entry.expected],
+          context,
+          fileStructure: parseFileStructure({ source: entry.source }),
+        })
+      ).toHaveLength(1);
+    }
   });
 
   it("includes conventionName when provided", () => {

--- a/packages/konsistent/src/typescript/predicates/export-values.ts
+++ b/packages/konsistent/src/typescript/predicates/export-values.ts
@@ -4,7 +4,7 @@ import { createDiagnostic } from "../../core/diagnostics.js";
 import type { FileStructure } from "../types.js";
 
 export function checkExportValues(opts: {
-  expected: (string | { name: string; from?: string })[];
+  expected: (string | { alias?: string; name: string; from?: string })[];
   predicateName?: "export" | "exportValues";
   context: PredicateContext;
   fileStructure: FileStructure;
@@ -22,27 +22,44 @@ export function checkExportValues(opts: {
   const diagnostics: Diagnostic[] = [];
 
   for (const entry of expected) {
-    const definition = typeof entry === "string" ? { name: entry } : entry;
+    const definition: { alias?: string; name: string; from?: string } =
+      typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = context.resolveTemplate(definition.name);
     const resolvedFrom = definition.from
       ? context.resolveTemplate(definition.from)
       : undefined;
+    const resolvedAlias =
+      definition.alias === undefined
+        ? undefined
+        : context.resolveTemplate(definition.alias);
 
-    const found = fileStructure.exports.some(
-      (e) =>
-        e.name === resolvedName &&
-        !e.isType &&
-        (resolvedFrom === undefined || e.from === resolvedFrom)
-    );
+    const found =
+      resolvedAlias === undefined || predicateName === "export"
+        ? fileStructure.exports.some(
+            (e) =>
+              e.name === resolvedName &&
+              !e.isType &&
+              (resolvedFrom === undefined || e.from === resolvedFrom)
+          )
+        : fileStructure.namedExportSymbols.some(
+            (e) =>
+              e.sourceName !== "default" &&
+              e.sourceName === resolvedName &&
+              e.name === resolvedAlias &&
+              !e.isType &&
+              (resolvedFrom === undefined || e.from === resolvedFrom)
+          );
 
     if (!found) {
       diagnostics.push(
         createDiagnostic({
           filePath: context.path,
           predicateName,
-          message: resolvedFrom
-            ? `Missing export "${resolvedName}" from "${resolvedFrom}"`
-            : `Missing export "${resolvedName}"`,
+          message: formatMissingExportMessage({
+            name: resolvedName,
+            alias: resolvedAlias,
+            from: resolvedFrom,
+          }),
           conventionName,
           severity,
         })
@@ -51,4 +68,14 @@ export function checkExportValues(opts: {
   }
 
   return diagnostics;
+}
+
+function formatMissingExportMessage(opts: {
+  name: string;
+  alias?: string;
+  from?: string;
+}): string {
+  const alias = opts.alias === undefined ? "" : ` as "${opts.alias}"`;
+  const from = opts.from === undefined ? "" : ` from "${opts.from}"`;
+  return `Missing export "${opts.name}"${alias}${from}`;
 }

--- a/packages/konsistent/src/typescript/predicates/import-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
 import type { FileStructure } from "../types.js";
 import { checkImportTypes } from "./import-types.js";
 
@@ -186,6 +187,101 @@ describe("checkImportTypes", () => {
       }),
     });
     expect(result).toEqual([]);
+  });
+
+  it("matches an aliased named type import by its original name", () => {
+    const result = checkImportTypes({
+      expected: ["SourceType"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import type { SourceType as LocalType } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("does not match an aliased named type import by only its local name", () => {
+    const result = checkImportTypes({
+      expected: ["LocalType"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import type { SourceType as LocalType } from "pkg";',
+      }),
+    });
+    expect(result[0].message).toBe('Missing import type "LocalType"');
+  });
+
+  it("requires an exact alias when configured", () => {
+    const source =
+      'import { type SourceType as LocalType } from "type-package";';
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkImportTypes({
+        expected: [
+          { name: "SourceType", alias: "LocalType", from: "type-package" },
+        ],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })
+    ).toEqual([]);
+    expect(
+      checkImportTypes({
+        expected: [{ name: "SourceType", alias: "OtherType" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })[0].message
+    ).toBe('Missing import type "SourceType" as "OtherType"');
+  });
+
+  it("allows an alias equal to the source name for a named type import", () => {
+    const result = checkImportTypes({
+      expected: [{ name: "SourceType", alias: "SourceType" }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import type { SourceType } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("resolves template placeholders in aliases", () => {
+    const result = checkImportTypes({
+      expected: [{ name: "SourceType", alias: "${name}Type" }],
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { name: { toString: () => "Local" } },
+      }),
+      fileStructure: parseFileStructure({
+        source: 'import type { SourceType as LocalType } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it.each([
+    {
+      source: 'import type DefaultType from "pkg";',
+      expected: { name: "default", alias: "DefaultType" },
+    },
+    {
+      source: 'import type * as NamespaceType from "pkg";',
+      expected: { name: "*", alias: "NamespaceType" },
+    },
+    {
+      source: 'import type { default as DefaultType } from "pkg";',
+      expected: { name: "default", alias: "DefaultType" },
+    },
+  ])("does not apply aliases to default or namespace type imports: $source", ({
+    source,
+    expected,
+  }) => {
+    const result = checkImportTypes({
+      expected: [expected],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({ source }),
+    });
+    expect(result).toHaveLength(1);
   });
 
   it("includes conventionName when provided", () => {

--- a/packages/konsistent/src/typescript/predicates/import-types.ts
+++ b/packages/konsistent/src/typescript/predicates/import-types.ts
@@ -4,7 +4,7 @@ import { createDiagnostic } from "../../core/diagnostics.js";
 import type { FileStructure } from "../types.js";
 
 export function checkImportTypes(opts: {
-  expected: (string | { name: string; from?: string })[];
+  expected: (string | { alias?: string; name: string; from?: string })[];
   context: PredicateContext;
   fileStructure: FileStructure;
   conventionName?: string;
@@ -14,17 +14,26 @@ export function checkImportTypes(opts: {
   const diagnostics: Diagnostic[] = [];
 
   for (const entry of expected) {
-    const definition = typeof entry === "string" ? { name: entry } : entry;
+    const definition: { alias?: string; name: string; from?: string } =
+      typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = context.resolveTemplate(definition.name);
     const resolvedFrom = definition.from
       ? context.resolveTemplate(definition.from)
       : undefined;
+    const resolvedAlias =
+      definition.alias === undefined
+        ? undefined
+        : context.resolveTemplate(definition.alias);
 
     const found = fileStructure.imports.some(
       (i) =>
-        i.name === resolvedName &&
         i.isType &&
-        (resolvedFrom === undefined || i.from === resolvedFrom)
+        (resolvedFrom === undefined || i.from === resolvedFrom) &&
+        matchesImportName({
+          importInfo: i,
+          name: resolvedName,
+          alias: resolvedAlias,
+        })
     );
 
     if (!found) {
@@ -32,7 +41,10 @@ export function checkImportTypes(opts: {
         createDiagnostic({
           filePath: context.path,
           predicateName: "importTypes",
-          message: `Missing import type "${resolvedName}"`,
+          message:
+            resolvedAlias === undefined
+              ? `Missing import type "${resolvedName}"`
+              : `Missing import type "${resolvedName}" as "${resolvedAlias}"`,
           conventionName,
           severity,
         })
@@ -41,4 +53,24 @@ export function checkImportTypes(opts: {
   }
 
   return diagnostics;
+}
+
+function matchesImportName(opts: {
+  importInfo: FileStructure["imports"][number];
+  name: string;
+  alias?: string;
+}): boolean {
+  const { importInfo, name, alias } = opts;
+  if (alias !== undefined) {
+    return (
+      importInfo.kind === "named" &&
+      importInfo.sourceName !== "default" &&
+      importInfo.sourceName === name &&
+      importInfo.name === alias
+    );
+  }
+  if (importInfo.kind === "named" && importInfo.sourceName !== "default") {
+    return importInfo.sourceName === name;
+  }
+  return importInfo.name === name;
 }

--- a/packages/konsistent/src/typescript/predicates/import-values.test.ts
+++ b/packages/konsistent/src/typescript/predicates/import-values.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PredicateContext } from "../../core/context.js";
+import { parseFileStructure } from "../parser.js";
 import type { FileStructure } from "../types.js";
 import { checkImportValues } from "./import-values.js";
 
@@ -184,6 +185,126 @@ describe("checkImportValues", () => {
           },
         ],
       }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("matches an aliased named import by its original name", () => {
+    const result = checkImportValues({
+      expected: ["sourceValue"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import { sourceValue as localValue } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("does not match an aliased named import by only its local name", () => {
+    const result = checkImportValues({
+      expected: ["localValue"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import { sourceValue as localValue } from "pkg";',
+      }),
+    });
+    expect(result[0].message).toBe('Missing import "localValue"');
+  });
+
+  it("preserves local-name matching for the deprecated import predicate", () => {
+    const result = checkImportValues({
+      expected: ["localValue"],
+      predicateName: "import",
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import { sourceValue as localValue } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("requires an exact alias when configured", () => {
+    const source = 'import { sourceValue as localValue } from "pkg";';
+    const context = createMockContext({ path: "src/index.ts" });
+
+    expect(
+      checkImportValues({
+        expected: [{ name: "sourceValue", alias: "localValue", from: "pkg" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })
+    ).toEqual([]);
+    expect(
+      checkImportValues({
+        expected: [{ name: "sourceValue", alias: "otherValue" }],
+        context,
+        fileStructure: parseFileStructure({ source }),
+      })[0].message
+    ).toBe('Missing import "sourceValue" as "otherValue"');
+  });
+
+  it("allows an alias equal to the source name for a named import", () => {
+    const result = checkImportValues({
+      expected: [{ name: "sourceValue", alias: "sourceValue" }],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source: 'import { sourceValue } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("resolves template placeholders in aliases", () => {
+    const result = checkImportValues({
+      expected: [{ name: "sourceValue", alias: "${name}Value" }],
+      context: createMockContext({
+        path: "src/index.ts",
+        placeholders: { name: { toString: () => "local" } },
+      }),
+      fileStructure: parseFileStructure({
+        source: 'import { sourceValue as localValue } from "pkg";',
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it.each([
+    {
+      source: 'import DefaultValue from "pkg";',
+      expected: { name: "default", alias: "DefaultValue" },
+    },
+    {
+      source: 'import * as NamespaceValue from "pkg";',
+      expected: { name: "*", alias: "NamespaceValue" },
+    },
+    {
+      source: 'import { default as DefaultValue } from "pkg";',
+      expected: { name: "default", alias: "DefaultValue" },
+    },
+  ])("does not apply aliases to default or namespace imports: $source", ({
+    source,
+    expected,
+  }) => {
+    const result = checkImportValues({
+      expected: [expected],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({ source }),
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it("preserves alias-less matching for default and namespace imports", () => {
+    const fileStructure = parseFileStructure({
+      source: [
+        'import DefaultValue from "default-pkg";',
+        'import * as NamespaceValue from "namespace-pkg";',
+        'import { default as NamedDefault } from "named-default-pkg";',
+      ].join("\n"),
+    });
+    const result = checkImportValues({
+      expected: ["DefaultValue", "NamespaceValue", "NamedDefault"],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure,
     });
     expect(result).toEqual([]);
   });

--- a/packages/konsistent/src/typescript/predicates/import-values.ts
+++ b/packages/konsistent/src/typescript/predicates/import-values.ts
@@ -4,7 +4,7 @@ import { createDiagnostic } from "../../core/diagnostics.js";
 import type { FileStructure } from "../types.js";
 
 export function checkImportValues(opts: {
-  expected: (string | { name: string; from?: string })[];
+  expected: (string | { alias?: string; name: string; from?: string })[];
   predicateName?: "import" | "importValues";
   context: PredicateContext;
   fileStructure: FileStructure;
@@ -22,17 +22,28 @@ export function checkImportValues(opts: {
   const diagnostics: Diagnostic[] = [];
 
   for (const entry of expected) {
-    const definition = typeof entry === "string" ? { name: entry } : entry;
+    const definition: { alias?: string; name: string; from?: string } =
+      typeof entry === "string" ? { name: entry } : entry;
     const resolvedName = context.resolveTemplate(definition.name);
     const resolvedFrom = definition.from
       ? context.resolveTemplate(definition.from)
       : undefined;
+    const resolvedAlias =
+      definition.alias === undefined
+        ? undefined
+        : context.resolveTemplate(definition.alias);
 
     const found = fileStructure.imports.some(
       (i) =>
-        i.name === resolvedName &&
         !i.isType &&
-        (resolvedFrom === undefined || i.from === resolvedFrom)
+        (resolvedFrom === undefined || i.from === resolvedFrom) &&
+        (predicateName === "import"
+          ? i.name === resolvedName
+          : matchesImportName({
+              importInfo: i,
+              name: resolvedName,
+              alias: resolvedAlias,
+            }))
     );
 
     if (!found) {
@@ -40,7 +51,10 @@ export function checkImportValues(opts: {
         createDiagnostic({
           filePath: context.path,
           predicateName,
-          message: `Missing import "${resolvedName}"`,
+          message:
+            resolvedAlias === undefined
+              ? `Missing import "${resolvedName}"`
+              : `Missing import "${resolvedName}" as "${resolvedAlias}"`,
           conventionName,
           severity,
         })
@@ -49,4 +63,24 @@ export function checkImportValues(opts: {
   }
 
   return diagnostics;
+}
+
+function matchesImportName(opts: {
+  importInfo: FileStructure["imports"][number];
+  name: string;
+  alias?: string;
+}): boolean {
+  const { importInfo, name, alias } = opts;
+  if (alias !== undefined) {
+    return (
+      importInfo.kind === "named" &&
+      importInfo.sourceName !== "default" &&
+      importInfo.sourceName === name &&
+      importInfo.name === alias
+    );
+  }
+  if (importInfo.kind === "named" && importInfo.sourceName !== "default") {
+    return importInfo.sourceName === name;
+  }
+  return importInfo.name === name;
 }

--- a/packages/konsistent/src/typescript/types.ts
+++ b/packages/konsistent/src/typescript/types.ts
@@ -14,8 +14,10 @@ export interface ExportInfo {
 export interface ImportInfo {
   from: string;
   isType: boolean;
+  kind: "default" | "named" | "namespace";
   name: string;
   pos: SourcePosition;
+  sourceName?: string;
 }
 
 export type DeclarationSymbolKind =


### PR DESCRIPTION
## Pull Request Description

Adds optional alias requirements to `importValues`, `importTypes`, `exportValues`, and `exportTypes` so conventions can enforce both a symbol's original name and its local or public name.

- Supports `alias` alongside `name`, `from`, and type schemas.
- Applies exact alias-pair behavior to both `must` and `mustNot`.
- Adds unit and e2e coverage for value/type imports and exports, including re-exports and alias-insensitive checks.
- Updates generated schemas and predicate documentation.

## Relevant technical choices

For named symbols, `name` now identifies the original imported or exported name, while `alias` identifies the local import binding or public export name. Omitting `alias` ignores the resulting name. Default and namespace forms remain outside alias matching, and deprecated predicates retain their existing schemas and behavior.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
