### PR TITLE
feat(konsistent): allow filtering paths covered via `--paths`, `--modified`, and `--staged` flags

### DIFF
--- a/.changeset/long-kids-yell.md
+++ b/.changeset/long-kids-yell.md
@@ -1,0 +1,5 @@
+---
+"konsistent": patch
+---
+
+feat(konsistent): allow filtering paths covered via `--paths`, `--modified`, and `--staged` flags

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -83,7 +83,19 @@ For custom reports, gating, or agent workflows, use [`--format=json`](../referen
 
 ## Pre-commit / pre-push
 
-For a local guard before pushing, add a husky or lefthook hook that runs `pnpm konsistent`. Since `konsistent` checks the whole codebase rather than individual files, prefer running it in CI and reserving local hooks for the fastest checks. If you do run it pre-push, use `--diagnostic-level error` to keep it snappy.
+For a fast local guard, check only files staged for the next commit:
+
+```bash
+pnpm konsistent --staged
+```
+
+For a broader pre-push check that includes staged changes, unstaged changes, and untracked files that are not ignored by Git, use:
+
+```bash
+pnpm konsistent --modified
+```
+
+Both commands restrict path discovery before conventions run. If Git selects no files, Konsistent prints a warning and exits successfully. A full `pnpm konsistent` remains the authoritative whole-codebase check for CI.
 
 ## Combining with other checks
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,9 @@ konsistent check
 konsistent check --config-package @acme/shared-conventions
 konsistent check --format=json --max-diagnostics=1000
 konsistent check --error-on-warnings --diagnostic-level error
+konsistent check --paths packages/core --paths 'packages/ui/**/*.tsx'
+konsistent check --staged
+konsistent check --modified
 ```
 
 ### Flags
@@ -39,11 +42,22 @@ konsistent check --error-on-warnings --diagnostic-level error
 | `--error-on-warnings` | boolean | `false` | Treat warnings as errors for the exit code |
 | `--diagnostic-level <level>` | `warning` \| `error` | `warning` | Minimum severity to evaluate. `error` skips warning-severity conventions entirely |
 | `--placeholder <name:value>` | string (repeatable) | — | Inject a placeholder into every convention's `placeholders` map, overriding any entry already there. May be passed multiple times. See [Static placeholder values](./path-patterns.md#static-placeholder-values) |
+| `--paths <path-or-glob>` | string (repeatable) | — | Check concrete files, recursive directories, or glob patterns relative to the current directory |
+| `--staged` | boolean | `false` | Check files added, copied, modified, or renamed in the Git index |
+| `--modified` | boolean | `false` | Check staged and unstaged tracked changes plus untracked files that are not ignored by Git |
+
+`--paths`, `--staged`, and `--modified` are mutually exclusive. Without one of them, `check` continues to evaluate the full codebase under the current directory.
+
+Quote glob patterns so Konsistent expands them consistently instead of relying on shell expansion. Concrete directories are recursive. Negated patterns may filter a positive selector but cannot be used alone. Absolute paths are accepted only when they remain inside the current directory. A selected file activates structural conventions for its ancestor directories, while nested `for.files` blocks remain restricted to selected descendants.
+
+Git modes use the repository containing the current directory and process the current contents on disk. `--staged` therefore includes unstaged edits made to a staged file. `--modified` also includes untracked files unless Git ignores them. Deleted paths cannot be checked and are excluded.
+
+When a selection contains no paths, Konsistent prints a warning to stderr, checks zero paths, and exits successfully. The warning is operational output rather than a convention diagnostic, so `--error-on-warnings` does not change that result and JSON stdout remains valid.
 
 ### Exit codes
 
 - `0` — no errors (warnings allowed unless `--error-on-warnings` is set).
-- `1` — errors found, or config could not be loaded.
+- `1` — errors found, config could not be loaded, selection flags conflict, or Git/path selection fails.
 
 ## `validate`
 

--- a/e2e/fixtures/path-selection/components/Button/Button.test.tsx
+++ b/e2e/fixtures/path-selection/components/Button/Button.test.tsx
@@ -1,0 +1,1 @@
+export const test = true;

--- a/e2e/fixtures/path-selection/components/Button/Button.tsx
+++ b/e2e/fixtures/path-selection/components/Button/Button.tsx
@@ -1,0 +1,3 @@
+export function Button() {
+  return "Button";
+}

--- a/e2e/fixtures/path-selection/components/Input/Input.test.tsx
+++ b/e2e/fixtures/path-selection/components/Input/Input.test.tsx
@@ -1,0 +1,1 @@
+export const test = true;

--- a/e2e/fixtures/path-selection/components/Input/Input.tsx
+++ b/e2e/fixtures/path-selection/components/Input/Input.tsx
@@ -1,0 +1,3 @@
+export function Input() {
+  return "Input";
+}

--- a/e2e/fixtures/path-selection/components/konsistent.json
+++ b/e2e/fixtures/path-selection/components/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "component-structure",
+      "paths": "{componentName}",
+      "must": [
+        { "must": { "haveFiles": ["${componentName}.tsx"] } },
+        {
+          "for": { "files": "${componentName}.test.tsx" },
+          "must": { "exportValues": ["describe"] }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/path-selection/konsistent.json
+++ b/e2e/fixtures/path-selection/konsistent.json
@@ -11,6 +11,11 @@
           "must": { "exportValues": ["describe"] }
         }
       ]
+    },
+    {
+      "name": "non-button-component",
+      "paths": "components/[!B]*/**/*.tsx",
+      "must": { "exportValues": ["nonButtonComponent"] }
     }
   ]
 }

--- a/e2e/fixtures/path-selection/konsistent.json
+++ b/e2e/fixtures/path-selection/konsistent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "conventions": [
+    {
+      "name": "component-structure",
+      "paths": "components/{componentName}",
+      "must": [
+        { "must": { "haveFiles": ["${componentName}.tsx"] } },
+        {
+          "for": { "files": "${componentName}.test.tsx" },
+          "must": { "exportValues": ["describe"] }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/path-selection.test.ts
+++ b/e2e/path-selection.test.ts
@@ -1,0 +1,218 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCallback);
+const cliBinary = resolve(
+  import.meta.dirname,
+  "../packages/konsistent/dist/index.js"
+);
+const fixturePath = resolve(import.meta.dirname, "fixtures/path-selection");
+const temporaryDirectories = new Set<string>();
+
+function runCli(opts: { cwd: string; args: string[] }) {
+  return execFile("node", [cliBinary, ...opts.args], {
+    cwd: opts.cwd,
+    env: {
+      ...process.env,
+      GITHUB_ACTIONS: "",
+      KONSISTENT_NO_UPDATE_CHECK: "true",
+    },
+  });
+}
+
+function runGit(opts: { cwd: string; args: string[] }) {
+  return execFile("git", opts.args, { cwd: opts.cwd });
+}
+
+async function createFixtureCopy(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "konsistent-path-selection-"));
+  temporaryDirectories.add(cwd);
+  await cp(fixturePath, cwd, { recursive: true });
+  return cwd;
+}
+
+async function createGitFixture(opts: { commit: boolean }): Promise<string> {
+  const cwd = await createFixtureCopy();
+  await runGit({ cwd, args: ["init", "--quiet"] });
+  await runGit({ cwd, args: ["config", "user.email", "test@example.com"] });
+  await runGit({ cwd, args: ["config", "user.name", "Konsistent Tests"] });
+  await runGit({ cwd, args: ["config", "commit.gpgSign", "false"] });
+  if (opts.commit) {
+    await runGit({ cwd, args: ["add", "."] });
+    await runGit({
+      cwd,
+      args: ["commit", "--quiet", "-m", "Initial fixture"],
+    });
+  }
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    [...temporaryDirectories].map((path) =>
+      rm(path, { recursive: true, force: true })
+    )
+  );
+  temporaryDirectories.clear();
+});
+
+describe("--paths", () => {
+  it("restricts directory conventions to selected file descendants", async () => {
+    const result = await runCli({
+      cwd: fixturePath,
+      args: ["--paths", "components/Button/Button.tsx"],
+    });
+
+    expect(result.stdout).toContain("No violations found");
+    expect(result.stdout).not.toContain("Button.test.tsx");
+  });
+
+  it("accepts repeated concrete paths and glob patterns", async () => {
+    await expect(
+      runCli({
+        cwd: fixturePath,
+        args: [
+          "check",
+          "--paths",
+          "components/Button/Button.tsx",
+          "--paths=components/Input/*.test.tsx",
+        ],
+      })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("components/Input/Input.test.tsx"),
+    });
+  });
+
+  it("warns without failing when no paths match", async () => {
+    const result = await runCli({
+      cwd: fixturePath,
+      args: ["check", "--paths", "missing/**/*.ts"],
+    });
+
+    expect(result.stderr).toContain("No paths matched --paths");
+    expect(result.stdout).toContain("Checked 0 files");
+  });
+
+  it("keeps empty-selection warnings out of JSON stdout", async () => {
+    const result = await runCli({
+      cwd: fixturePath,
+      args: [
+        "check",
+        "--paths",
+        "missing/**/*.ts",
+        "--format",
+        "json",
+        "--error-on-warnings",
+      ],
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual([]);
+    expect(result.stderr).toContain("No paths matched --paths");
+  });
+});
+
+describe("Git path selection", () => {
+  it.each([
+    ["--staged", "No staged files found"],
+    ["--modified", "No modified files found"],
+  ])("warns without failing when %s selects nothing", async (flag, warning) => {
+    const cwd = await createGitFixture({ commit: true });
+    const result = await runCli({ cwd, args: ["check", flag] });
+
+    expect(result.stderr).toContain(warning);
+    expect(result.stdout).toContain("Checked 0 files");
+  });
+
+  it("reports a Git error outside a repository", async () => {
+    const cwd = await createFixtureCopy();
+
+    await expect(
+      runCli({ cwd, args: ["check", "--staged"] })
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("not a git repository"),
+    });
+  });
+
+  it("supports staged and modified selection before the first commit", async () => {
+    const cwd = await createGitFixture({ commit: false });
+
+    await expect(
+      runCli({ cwd, args: ["check", "--modified"] })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("components/Button/Button.test.tsx"),
+    });
+
+    await runGit({ cwd, args: ["add", "components/Button/Button.test.tsx"] });
+    await expect(
+      runCli({ cwd, args: ["check", "--staged"] })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("components/Button/Button.test.tsx"),
+    });
+  });
+
+  it("normalizes Git paths relative to a subdirectory invocation", async () => {
+    const cwd = await createGitFixture({ commit: true });
+    const componentsCwd = join(cwd, "components");
+    await writeFile(
+      join(componentsCwd, "Input/Input.test.tsx"),
+      "export const changedInputTest = true;\n"
+    );
+
+    await expect(
+      runCli({ cwd: componentsCwd, args: ["check", "--modified"] })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("Input/Input.test.tsx"),
+    });
+  });
+
+  it("separates staged files from all modified files and reads disk content", async () => {
+    const cwd = await createGitFixture({ commit: true });
+    const buttonTest = join(cwd, "components/Button/Button.test.tsx");
+    const inputTest = join(cwd, "components/Input/Input.test.tsx");
+    await writeFile(buttonTest, "export const describe = true;\n");
+    await runGit({ cwd, args: ["add", "components/Button/Button.test.tsx"] });
+    await writeFile(buttonTest, "export const test = false;\n");
+    await writeFile(inputTest, "export const inputTest = true;\n");
+
+    await mkdir(join(cwd, "components/Card"), { recursive: true });
+    await writeFile(
+      join(cwd, "components/Card/Card.tsx"),
+      'export function Card() { return "Card"; }\n'
+    );
+    await writeFile(
+      join(cwd, "components/Card/Card.test.tsx"),
+      "export const cardTest = true;\n"
+    );
+    await writeFile(join(cwd, ".gitignore"), "components/Ignored/\n");
+    await mkdir(join(cwd, "components/Ignored"), { recursive: true });
+    await writeFile(
+      join(cwd, "components/Ignored/Ignored.tsx"),
+      'export function Ignored() { return "Ignored"; }\n'
+    );
+    await writeFile(
+      join(cwd, "components/Ignored/Ignored.test.tsx"),
+      "export const ignoredTest = true;\n"
+    );
+
+    await expect(
+      runCli({ cwd, args: ["check", "--staged"] })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("components/Button/Button.test.tsx"),
+    });
+
+    try {
+      await runCli({ cwd, args: ["check", "--modified"] });
+      expect.fail("Expected modified files to report violations");
+    } catch (error: unknown) {
+      const result = error as { stdout: string };
+      expect(result.stdout).toContain("components/Button/Button.test.tsx");
+      expect(result.stdout).toContain("components/Input/Input.test.tsx");
+      expect(result.stdout).toContain("components/Card/Card.test.tsx");
+      expect(result.stdout).not.toContain("components/Ignored");
+    }
+  });
+});

--- a/e2e/path-selection.test.ts
+++ b/e2e/path-selection.test.ts
@@ -87,6 +87,53 @@ describe("--paths", () => {
     });
   });
 
+  it("matches bounded conventions with POSIX character classes", async () => {
+    const buttonResult = await runCli({
+      cwd: fixturePath,
+      args: ["check", "--paths", "components/Button/Button.tsx"],
+    });
+
+    expect(buttonResult.stdout).toContain("No violations found");
+    await expect(
+      runCli({
+        cwd: fixturePath,
+        args: ["check", "--paths", "components/Input/Input.tsx"],
+      })
+    ).rejects.toMatchObject({
+      stdout: expect.stringContaining("[non-button-component]"),
+    });
+  });
+
+  it("applies POSIX character classes in negative selectors", async () => {
+    try {
+      await runCli({
+        cwd: fixturePath,
+        args: [
+          "check",
+          "--paths",
+          "components/**/*.tsx",
+          "--paths",
+          "!components/[!B]*/**",
+        ],
+      });
+      expect.fail(
+        "Expected the selected Button test file to report violations"
+      );
+    } catch (error: unknown) {
+      const result = error as { stdout: string };
+      expect(result.stdout).toContain("components/Button/Button.test.tsx");
+      expect(result.stdout).not.toContain("components/Input/Input.test.tsx");
+    }
+  });
+
+  it("rejects a separately supplied empty path", async () => {
+    await expect(
+      runCli({ cwd: fixturePath, args: ["check", "--paths", ""] })
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("--paths requires a non-empty value"),
+    });
+  });
+
   it("warns without failing when no paths match", async () => {
     const result = await runCli({
       cwd: fixturePath,

--- a/packages/konsistent/package.json
+++ b/packages/konsistent/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@konsistent/convention": "workspace:*",
     "citty": "catalog:",
+    "picomatch": "^4.0.4",
     "picocolors": "^1",
     "resolve.exports": "^2",
     "tinyglobby": "^0.2",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/picomatch": "^4.0.2",
     "ajv": "catalog:",
     "del-cli": "catalog:",
     "tsup": "catalog:",

--- a/packages/konsistent/src/commands/check.ts
+++ b/packages/konsistent/src/commands/check.ts
@@ -5,13 +5,17 @@ import {
   normalizePlaceholderArg,
   parseCliPlaceholders,
 } from "../config/index.js";
-import type { Reporter } from "../core/index.js";
+import type { FileSystem, PathSelection, Reporter } from "../core/index.js";
 import {
+  allPathSelection,
   createDefaultReporter,
+  createGitClient,
   createGithubReporter,
   createJsonReporter,
   createMarkdownReporter,
   createRealFileSystem,
+  createTargetedPathSelection,
+  resolvePathSelectors,
   run,
 } from "../core/index.js";
 import {
@@ -19,6 +23,7 @@ import {
   truncateDiagnostics,
 } from "../core/truncate-diagnostics.js";
 import { printDeprecationWarnings } from "./print-deprecation-warnings.js";
+import { parseRepeatedStringOption } from "./repeated-string-option.js";
 
 const checkArgs = {
   "config-path": {
@@ -65,7 +70,115 @@ const checkArgs = {
     description:
       'Inject a placeholder value into every convention\'s placeholders map (overriding any existing entry). Format: "name:value". May be passed multiple times.',
   },
+  paths: {
+    type: "string" as const,
+    description:
+      "Path or glob to check. May be passed multiple times. Mutually exclusive with --staged and --modified.",
+  },
+  staged: {
+    type: "boolean" as const,
+    description: "Check files currently staged in Git",
+    default: false,
+  },
+  modified: {
+    type: "boolean" as const,
+    description:
+      "Check staged, unstaged, and untracked files that are not ignored by Git",
+    default: false,
+  },
 };
+
+interface PathSelectionOptions {
+  modified: boolean;
+  paths: string[];
+  staged: boolean;
+}
+
+type PathSelectionOptionsResult =
+  | { success: true; options: PathSelectionOptions }
+  | { success: false; error: string };
+
+function parsePathSelectionOptions(opts: {
+  rawArgs: string[];
+  staged: boolean;
+  modified: boolean;
+}): PathSelectionOptionsResult {
+  const pathArgsResult = parseRepeatedStringOption({
+    rawArgs: opts.rawArgs,
+    name: "--paths",
+  });
+  if (!pathArgsResult.success) {
+    return pathArgsResult;
+  }
+
+  const selectionModeCount =
+    Number(pathArgsResult.values.length > 0) +
+    Number(opts.staged) +
+    Number(opts.modified);
+  if (selectionModeCount > 1) {
+    return {
+      success: false,
+      error: "--paths, --staged, and --modified are mutually exclusive",
+    };
+  }
+
+  return {
+    success: true,
+    options: {
+      paths: pathArgsResult.values,
+      staged: opts.staged,
+      modified: opts.modified,
+    },
+  };
+}
+
+async function resolveCheckPathSelection(opts: {
+  options: PathSelectionOptions;
+  cwd: string;
+  fileSystem: FileSystem;
+}): Promise<{ pathSelection: PathSelection; emptyWarning?: string }> {
+  if (opts.options.paths.length > 0) {
+    return {
+      pathSelection: await resolvePathSelectors({
+        selectors: opts.options.paths,
+        cwd: opts.cwd,
+        fileSystem: opts.fileSystem,
+      }),
+      emptyWarning: "No paths matched --paths. Nothing to check.",
+    };
+  }
+
+  if (opts.options.staged || opts.options.modified) {
+    const gitClient = createGitClient({
+      cwd: opts.cwd,
+      fileSystem: opts.fileSystem,
+    });
+    const selectedPaths = opts.options.staged
+      ? await gitClient.listStagedPaths()
+      : await gitClient.listModifiedPaths();
+    return {
+      pathSelection: createTargetedPathSelection({ selectedPaths }),
+      emptyWarning: opts.options.staged
+        ? "No staged files found. Nothing to check."
+        : "No modified files found. Nothing to check.",
+    };
+  }
+
+  return { pathSelection: allPathSelection };
+}
+
+function printEmptySelectionWarning(opts: {
+  pathSelection: PathSelection;
+  warning?: string;
+}): void {
+  if (
+    opts.pathSelection.mode === "targeted" &&
+    opts.pathSelection.selectedPaths.length === 0 &&
+    opts.warning
+  ) {
+    console.warn(pc.yellow(opts.warning));
+  }
+}
 
 export function resolveFormat(opts: { format: string }): string {
   if (opts.format !== "default") {
@@ -96,7 +209,18 @@ export default defineCommand({
     description: "Check structural conventions",
   },
   args: checkArgs,
-  async run({ args }) {
+  async run({ args, rawArgs }) {
+    const pathSelectionOptions = parsePathSelectionOptions({
+      rawArgs,
+      staged: args.staged,
+      modified: args.modified,
+    });
+    if (!pathSelectionOptions.success) {
+      console.error(pc.red(pathSelectionOptions.error));
+      process.exit(1);
+      return;
+    }
+
     const cliPlaceholdersResult = parseCliPlaceholders({
       raw: normalizePlaceholderArg(args.placeholder),
     });
@@ -132,9 +256,31 @@ export default defineCommand({
         : result.config;
 
     const fileSystem = createRealFileSystem({ cwd: process.cwd() });
+    let resolvedPathSelection: Awaited<
+      ReturnType<typeof resolveCheckPathSelection>
+    >;
+    try {
+      resolvedPathSelection = await resolveCheckPathSelection({
+        options: pathSelectionOptions.options,
+        cwd: process.cwd(),
+        fileSystem,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(pc.red(message));
+      process.exit(1);
+      return;
+    }
+
+    printEmptySelectionWarning({
+      pathSelection: resolvedPathSelection.pathSelection,
+      warning: resolvedPathSelection.emptyWarning,
+    });
+
     const runResult = await run({
       config,
       fileSystem,
+      pathSelection: resolvedPathSelection.pathSelection,
     });
 
     const maxDiags = Number.parseInt(args["max-diagnostics"], 10) || 100;

--- a/packages/konsistent/src/commands/commands.test.ts
+++ b/packages/konsistent/src/commands/commands.test.ts
@@ -73,6 +73,57 @@ describe("check command", () => {
   });
 });
 
+describe("check command path selection", () => {
+  it("accepts repeated --paths values", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+    await expect(
+      runCommand(checkCommand, {
+        rawArgs: ["--paths", "src/index.ts", "--paths=missing/**/*.ts"],
+      })
+    ).resolves.not.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns and succeeds when --paths selects nothing", async () => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+    await runCommand(checkCommand, {
+      rawArgs: ["--paths", "missing/**/*.ts"],
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No paths matched --paths")
+    );
+  });
+
+  it.each([
+    ["--paths", "src/index.ts", "--staged"],
+    ["--paths", "src/index.ts", "--modified"],
+    ["--staged", "--modified"],
+  ])("rejects mutually exclusive selectors: %s", async (...rawArgs) => {
+    vi.spyOn(process, "cwd").mockReturnValue(emptyConfigPath);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+    await runCommand(checkCommand, { rawArgs });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("mutually exclusive")
+    );
+  });
+});
+
 describe("check command --error-on-warnings", () => {
   it("exits 1 when warnings exist and flag is set", async () => {
     vi.spyOn(process, "cwd").mockReturnValue(warningsOnlyPath);
@@ -284,6 +335,9 @@ describe("help command", () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("check"));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("validate"));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("version"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("--paths"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("--staged"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("--modified"));
   });
 });
 

--- a/packages/konsistent/src/commands/help.ts
+++ b/packages/konsistent/src/commands/help.ts
@@ -22,6 +22,9 @@ Check options:
   --no-colors                Disable colored output (only for default format)
   --error-on-warnings        Treat warnings as errors for exit code purposes
   --diagnostic-level <level> Minimum severity to evaluate: warning (default) or error
+  --paths <path-or-glob>      Path or glob to check (repeatable)
+  --staged                    Check files currently staged in Git
+  --modified                  Check staged, unstaged, and untracked non-ignored files
 
 Validate options:
   --config-path <path>    Path to konsistent.json config file

--- a/packages/konsistent/src/commands/repeated-string-option.test.ts
+++ b/packages/konsistent/src/commands/repeated-string-option.test.ts
@@ -42,5 +42,14 @@ describe("parseRepeatedStringOption", () => {
       success: false,
       error: "--paths requires a non-empty value",
     });
+    expect(
+      parseRepeatedStringOption({
+        rawArgs: ["--paths", ""],
+        name: "--paths",
+      })
+    ).toEqual({
+      success: false,
+      error: "--paths requires a non-empty value",
+    });
   });
 });

--- a/packages/konsistent/src/commands/repeated-string-option.test.ts
+++ b/packages/konsistent/src/commands/repeated-string-option.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseRepeatedStringOption } from "./repeated-string-option.js";
+
+describe("parseRepeatedStringOption", () => {
+  it("collects separate and assigned values", () => {
+    expect(
+      parseRepeatedStringOption({
+        rawArgs: ["--paths", "src/index.ts", "--paths=packages/**/*.ts"],
+        name: "--paths",
+      })
+    ).toEqual({
+      success: true,
+      values: ["src/index.ts", "packages/**/*.ts"],
+    });
+  });
+
+  it("ignores unrelated options", () => {
+    expect(
+      parseRepeatedStringOption({
+        rawArgs: ["--format", "json", "--staged"],
+        name: "--paths",
+      })
+    ).toEqual({ success: true, values: [] });
+  });
+
+  it("rejects missing and empty values", () => {
+    expect(
+      parseRepeatedStringOption({
+        rawArgs: ["--paths"],
+        name: "--paths",
+      })
+    ).toEqual({
+      success: false,
+      error: "--paths requires a non-empty value",
+    });
+    expect(
+      parseRepeatedStringOption({
+        rawArgs: ["--paths="],
+        name: "--paths",
+      })
+    ).toEqual({
+      success: false,
+      error: "--paths requires a non-empty value",
+    });
+  });
+});

--- a/packages/konsistent/src/commands/repeated-string-option.ts
+++ b/packages/konsistent/src/commands/repeated-string-option.ts
@@ -28,7 +28,7 @@ export function parseRepeatedStringOption(opts: {
     }
 
     const value = opts.rawArgs[index + 1];
-    if (value === undefined || value.startsWith("-")) {
+    if (value === undefined || value.length === 0 || value.startsWith("-")) {
       return {
         success: false,
         error: `${opts.name} requires a non-empty value`,

--- a/packages/konsistent/src/commands/repeated-string-option.ts
+++ b/packages/konsistent/src/commands/repeated-string-option.ts
@@ -1,0 +1,42 @@
+export type RepeatedStringOptionResult =
+  | { success: true; values: string[] }
+  | { success: false; error: string };
+
+export function parseRepeatedStringOption(opts: {
+  rawArgs: string[];
+  name: string;
+}): RepeatedStringOptionResult {
+  const values: string[] = [];
+  const assignmentPrefix = `${opts.name}=`;
+
+  for (let index = 0; index < opts.rawArgs.length; index++) {
+    const arg = opts.rawArgs[index];
+    if (arg.startsWith(assignmentPrefix)) {
+      const value = arg.slice(assignmentPrefix.length);
+      if (value.length === 0) {
+        return {
+          success: false,
+          error: `${opts.name} requires a non-empty value`,
+        };
+      }
+      values.push(value);
+      continue;
+    }
+
+    if (arg !== opts.name) {
+      continue;
+    }
+
+    const value = opts.rawArgs[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+      return {
+        success: false,
+        error: `${opts.name} requires a non-empty value`,
+      };
+    }
+    values.push(value);
+    index++;
+  }
+
+  return { success: true, values };
+}

--- a/packages/konsistent/src/core/git-client.test.ts
+++ b/packages/konsistent/src/core/git-client.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FileSystem } from "./filesystem.js";
+import { createGitClient, parseNullDelimitedPaths } from "./git-client.js";
+
+function createMockFileSystem(files: string[]): FileSystem {
+  const paths = new Set(files);
+  return {
+    fileExists: (path) => paths.has(path),
+    glob: () => Promise.resolve([]),
+    isDirectory: () => false,
+    isFile: (path) => paths.has(path),
+    readDir: () => [],
+    readFile: () => "",
+  };
+}
+
+describe("parseNullDelimitedPaths", () => {
+  it("preserves spaces and newlines in paths", () => {
+    expect(
+      parseNullDelimitedPaths(
+        Buffer.from("src/with space.ts\0src/with\nnewline.ts\0")
+      )
+    ).toEqual(["src/with space.ts", "src/with\nnewline.ts"]);
+  });
+});
+
+describe("createGitClient", () => {
+  it("lists staged regular files with Biome-compatible status filtering", async () => {
+    const runGit = vi.fn((opts: { args: string[]; cwd: string }) => {
+      if (opts.args[0] === "rev-parse") {
+        return Promise.resolve(Buffer.from("true\n"));
+      }
+      return Promise.resolve(
+        Buffer.from("src/a.ts\0src/deleted.ts\0src/with space.ts\0")
+      );
+    });
+    const client = createGitClient({
+      cwd: "/repo",
+      fileSystem: createMockFileSystem(["src/a.ts", "src/with space.ts"]),
+      runGit,
+    });
+
+    await expect(client.listStagedPaths()).resolves.toEqual([
+      "src/a.ts",
+      "src/with space.ts",
+    ]);
+    expect(runGit).toHaveBeenNthCalledWith(1, {
+      args: ["rev-parse", "--is-inside-work-tree"],
+      cwd: "/repo",
+    });
+    expect(runGit).toHaveBeenNthCalledWith(2, {
+      args: [
+        "diff",
+        "--name-only",
+        "--relative",
+        "-z",
+        "--cached",
+        "--diff-filter=ACMR",
+        "--",
+      ],
+      cwd: "/repo",
+    });
+  });
+
+  it("unions staged, unstaged, and untracked modified paths", async () => {
+    const runGit = vi.fn((opts: { args: string[]; cwd: string }) => {
+      if (opts.args[0] === "rev-parse") {
+        return Promise.resolve(Buffer.from("true\n"));
+      }
+      if (opts.args[0] === "ls-files") {
+        return Promise.resolve(Buffer.from("src/untracked.ts\0"));
+      }
+      if (opts.args.includes("--cached")) {
+        return Promise.resolve(Buffer.from("src/staged.ts\0src/shared.ts\0"));
+      }
+      return Promise.resolve(Buffer.from("src/unstaged.ts\0src/shared.ts\0"));
+    });
+    const client = createGitClient({
+      cwd: "/repo",
+      fileSystem: createMockFileSystem([
+        "src/shared.ts",
+        "src/staged.ts",
+        "src/unstaged.ts",
+        "src/untracked.ts",
+      ]),
+      runGit,
+    });
+
+    await expect(client.listModifiedPaths()).resolves.toEqual([
+      "src/shared.ts",
+      "src/staged.ts",
+      "src/unstaged.ts",
+      "src/untracked.ts",
+    ]);
+    expect(runGit).toHaveBeenCalledTimes(4);
+    expect(runGit).toHaveBeenCalledWith({
+      args: ["ls-files", "--others", "--exclude-standard", "-z", "--"],
+      cwd: "/repo",
+    });
+  });
+
+  it("caches repository validation and propagates Git errors", async () => {
+    const runGit = vi
+      .fn<(opts: { args: string[]; cwd: string }) => Promise<Buffer>>()
+      .mockResolvedValueOnce(Buffer.from("true\n"))
+      .mockResolvedValueOnce(Buffer.alloc(0))
+      .mockRejectedValueOnce(new Error("fatal: not a git repository"));
+    const client = createGitClient({
+      cwd: "/repo",
+      fileSystem: createMockFileSystem([]),
+      runGit,
+    });
+
+    await expect(client.listStagedPaths()).resolves.toEqual([]);
+    await expect(client.listStagedPaths()).rejects.toThrow(
+      "fatal: not a git repository"
+    );
+    expect(
+      runGit.mock.calls.filter(([opts]) => opts.args[0] === "rev-parse")
+    ).toHaveLength(1);
+  });
+});

--- a/packages/konsistent/src/core/git-client.ts
+++ b/packages/konsistent/src/core/git-client.ts
@@ -1,0 +1,116 @@
+import { spawn } from "node:child_process";
+import { sep } from "node:path";
+import type { FileSystem } from "./filesystem.js";
+
+type RunGit = (opts: { args: string[]; cwd: string }) => Promise<Buffer>;
+
+export interface GitClient {
+  listModifiedPaths(): Promise<string[]>;
+  listStagedPaths(): Promise<string[]>;
+}
+
+function runGitCommand(opts: { args: string[]; cwd: string }): Promise<Buffer> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("git", opts.args, {
+      cwd: opts.cwd,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", (error) => {
+      rejectPromise(new Error(`Unable to run Git: ${error.message}`));
+    });
+    child.once("close", (code) => {
+      if (code !== 0) {
+        const details = Buffer.concat(stderr).toString("utf8").trim();
+        rejectPromise(
+          new Error(
+            details.length > 0 ? details : `Git exited with code ${code}`
+          )
+        );
+        return;
+      }
+      resolvePromise(Buffer.concat(stdout));
+    });
+  });
+}
+
+export function parseNullDelimitedPaths(output: Buffer): string[] {
+  const paths: string[] = [];
+  let start = 0;
+  for (let index = 0; index < output.length; index++) {
+    if (output[index] !== 0) {
+      continue;
+    }
+    if (index > start) {
+      paths.push(output.subarray(start, index).toString("utf8"));
+    }
+    start = index + 1;
+  }
+  if (start < output.length) {
+    paths.push(output.subarray(start).toString("utf8"));
+  }
+  return paths;
+}
+
+function normalizeGitPath(path: string): string {
+  return sep === "/" ? path : path.split(sep).join("/");
+}
+
+export function createGitClient(opts: {
+  cwd: string;
+  fileSystem: FileSystem;
+  runGit?: RunGit;
+}): GitClient {
+  const runGit = opts.runGit ?? runGitCommand;
+  let repositoryCheck: Promise<Buffer> | undefined;
+
+  function ensureRepository(): Promise<Buffer> {
+    repositoryCheck ??= runGit({
+      args: ["rev-parse", "--is-inside-work-tree"],
+      cwd: opts.cwd,
+    });
+    return repositoryCheck;
+  }
+
+  async function listPaths(commands: string[][]): Promise<string[]> {
+    await ensureRepository();
+    const outputs = await Promise.all(
+      commands.map((args) => runGit({ args, cwd: opts.cwd }))
+    );
+    const paths = new Set(
+      outputs
+        .flatMap(parseNullDelimitedPaths)
+        .map(normalizeGitPath)
+        .filter((path) => opts.fileSystem.isFile(path))
+    );
+    return [...paths].sort();
+  }
+
+  const stagedCommand = [
+    "diff",
+    "--name-only",
+    "--relative",
+    "-z",
+    "--cached",
+    "--diff-filter=ACMR",
+    "--",
+  ];
+
+  return {
+    listStagedPaths(): Promise<string[]> {
+      return listPaths([stagedCommand]);
+    },
+    listModifiedPaths(): Promise<string[]> {
+      return listPaths([
+        stagedCommand,
+        ["diff", "--name-only", "--relative", "-z", "--diff-filter=ACMR", "--"],
+        ["ls-files", "--others", "--exclude-standard", "-z", "--"],
+      ]);
+    },
+  };
+}

--- a/packages/konsistent/src/core/index.ts
+++ b/packages/konsistent/src/core/index.ts
@@ -3,8 +3,16 @@ export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export { createDiagnostic } from "./diagnostics.js";
 export type { FileSystem } from "./filesystem.js";
 export { createRealFileSystem } from "./filesystem.js";
+export type { GitClient } from "./git-client.js";
+export { createGitClient, parseNullDelimitedPaths } from "./git-client.js";
 export type { MatchedPath } from "./path-matcher.js";
 export { hasPlaceholders, matchPaths, patternToGlob } from "./path-matcher.js";
+export type { PathSelection } from "./path-selection.js";
+export {
+  allPathSelection,
+  createTargetedPathSelection,
+  resolvePathSelectors,
+} from "./path-selection.js";
 export { PlaceholderValue } from "./placeholder.js";
 export type { Reporter } from "./reporter.js";
 export {

--- a/packages/konsistent/src/core/path-matcher.test.ts
+++ b/packages/konsistent/src/core/path-matcher.test.ts
@@ -87,6 +87,35 @@ describe("matchPaths", () => {
     expect(globSpy).not.toHaveBeenCalled();
   });
 
+  it("matches POSIX character classes consistently for bounded candidates", async () => {
+    const fs = createMockFileSystem({
+      globResults: new Map([
+        [
+          "components/[!B]*/**",
+          ["components/Input/Input.tsx", "components/Input/Input.test.tsx"],
+        ],
+      ]),
+    });
+    const candidatePaths = [
+      "components/Button/Button.tsx",
+      "components/Button/Button.test.tsx",
+      "components/Input/Input.tsx",
+      "components/Input/Input.test.tsx",
+    ];
+
+    const fullResults = await matchPaths({
+      patterns: ["components/[!B]*/**"],
+      fileSystem: fs,
+    });
+    const boundedResults = await matchPaths({
+      patterns: ["components/[!B]*/**"],
+      fileSystem: fs,
+      candidatePaths,
+    });
+
+    expect(boundedResults).toEqual(fullResults);
+  });
+
   it("extracts placeholders from bounded candidates", async () => {
     const fs = createMockFileSystem({});
     const globSpy = vi.spyOn(fs, "glob");
@@ -120,6 +149,22 @@ describe("matchPaths", () => {
       "packages/core/index.ts",
     ]);
     expect(globSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies POSIX character classes in bounded negative patterns", async () => {
+    const fs = createMockFileSystem({});
+    const results = await matchPaths({
+      patterns: ["components/**", "!components/[!B]*"],
+      fileSystem: fs,
+      candidatePaths: [
+        "components/Button/Button.tsx",
+        "components/Input/Input.tsx",
+      ],
+    });
+
+    expect(results.map((result) => result.path)).toEqual([
+      "components/Button/Button.tsx",
+    ]);
   });
 
   it("does not fall back to globbing for an empty candidate set", async () => {

--- a/packages/konsistent/src/core/path-matcher.test.ts
+++ b/packages/konsistent/src/core/path-matcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { FileSystem } from "./filesystem.js";
 import { hasPlaceholders, matchPaths, patternToGlob } from "./path-matcher.js";
 
@@ -66,6 +66,70 @@ describe("patternToGlob", () => {
 });
 
 describe("matchPaths", () => {
+  it("matches bounded candidates without filesystem globbing", async () => {
+    const fs = createMockFileSystem({});
+    const globSpy = vi.spyOn(fs, "glob");
+    const results = await matchPaths({
+      patterns: ["src/**/*.ts"],
+      fileSystem: fs,
+      candidatePaths: ["src/index.ts", "src/nested/util.ts", "test/index.ts"],
+    });
+
+    expect(results.map((result) => result.path)).toEqual([
+      "src/index.ts",
+      "src/nested/util.ts",
+    ]);
+    expect(globSpy).not.toHaveBeenCalled();
+  });
+
+  it("extracts placeholders from bounded candidates", async () => {
+    const fs = createMockFileSystem({});
+    const globSpy = vi.spyOn(fs, "glob");
+    const results = await matchPaths({
+      patterns: ["components/{componentName}"],
+      fileSystem: fs,
+      candidatePaths: [
+        ".",
+        "components",
+        "components/Button",
+        "components/Button/Button.tsx",
+      ],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].path).toBe("components/Button");
+    expect(results[0].placeholders.componentName.toString()).toBe("Button");
+    expect(globSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies negated convention paths to bounded candidates", async () => {
+    const fs = createMockFileSystem({});
+    const globSpy = vi.spyOn(fs, "glob");
+    const results = await matchPaths({
+      patterns: ["packages/**/*.ts", "!packages/generated"],
+      fileSystem: fs,
+      candidatePaths: ["packages/core/index.ts", "packages/generated/index.ts"],
+    });
+
+    expect(results.map((result) => result.path)).toEqual([
+      "packages/core/index.ts",
+    ]);
+    expect(globSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to globbing for an empty candidate set", async () => {
+    const fs = createMockFileSystem({});
+    const globSpy = vi.spyOn(fs, "glob");
+    const results = await matchPaths({
+      patterns: ["src/**/*.ts"],
+      fileSystem: fs,
+      candidatePaths: [],
+    });
+
+    expect(results).toEqual([]);
+    expect(globSpy).not.toHaveBeenCalled();
+  });
+
   it("handles patterns without placeholders", async () => {
     const fs = createMockFileSystem({
       globResults: new Map([["src/**/*.ts", ["src/index.ts", "src/utils.ts"]]]),

--- a/packages/konsistent/src/core/path-matcher.ts
+++ b/packages/konsistent/src/core/path-matcher.ts
@@ -309,7 +309,7 @@ function matchCandidatePaths(opts: {
   patterns: string[];
   candidatePaths: readonly string[];
 }): string[] {
-  const isMatch = picomatch(opts.patterns);
+  const isMatch = picomatch(opts.patterns, { posix: true });
   return opts.candidatePaths.filter((path) => isMatch(path));
 }
 
@@ -482,7 +482,7 @@ export async function matchPaths(opts: {
 
   const negativeGlobs = negativePatterns.map(patternToGlob);
   if (candidatePaths !== undefined) {
-    const isNegativeMatch = picomatch(negativeGlobs);
+    const isNegativeMatch = picomatch(negativeGlobs, { posix: true });
     return positiveResults.filter((result) => {
       const pathAndAncestors = [result.path];
       let current = result.path;

--- a/packages/konsistent/src/core/path-matcher.ts
+++ b/packages/konsistent/src/core/path-matcher.ts
@@ -1,3 +1,4 @@
+import picomatch from "picomatch";
 import type { FileSystem } from "./filesystem.js";
 import { PlaceholderValue } from "./placeholder.js";
 import {
@@ -216,6 +217,14 @@ function tryExtractPlaceholders(opts: {
   return extracted;
 }
 
+function matchCandidatePaths(opts: {
+  patterns: string[];
+  candidatePaths: readonly string[];
+}): string[] {
+  const isMatch = picomatch(opts.patterns);
+  return opts.candidatePaths.filter((path) => isMatch(path));
+}
+
 function toPlaceholderMap(opts: {
   raw: Record<string, string>;
   kebabToPascalMap?: Record<string, string>;
@@ -252,6 +261,7 @@ function toPlaceholderMap(opts: {
 async function resolvePositivePatterns(opts: {
   patterns: string[];
   fileSystem: FileSystem;
+  candidatePaths?: readonly string[];
   kebabToPascalMap?: Record<string, string>;
   kebabToCamelMap?: Record<string, string>;
   pascalToKebabMap?: Record<string, string>;
@@ -262,6 +272,7 @@ async function resolvePositivePatterns(opts: {
   const {
     patterns,
     fileSystem,
+    candidatePaths,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -276,7 +287,10 @@ async function resolvePositivePatterns(opts: {
 
   const anyPlaceholders = patterns.some((p) => hasPlaceholders(p));
   if (!anyPlaceholders) {
-    const paths = await fileSystem.glob(patterns);
+    const paths =
+      candidatePaths === undefined
+        ? await fileSystem.glob(patterns)
+        : matchCandidatePaths({ patterns, candidatePaths });
     return paths.map((p) => ({
       path: p.endsWith("/") ? p.slice(0, -1) : p,
       placeholders: {},
@@ -284,7 +298,13 @@ async function resolvePositivePatterns(opts: {
   }
 
   const globPatterns = patterns.map(patternToGlob);
-  const matchedPaths = await fileSystem.glob(globPatterns);
+  const matchedPaths =
+    candidatePaths === undefined
+      ? await fileSystem.glob(globPatterns)
+      : matchCandidatePaths({
+          patterns: globPatterns,
+          candidatePaths,
+        });
   const results: MatchedPath[] = [];
 
   for (const rawPath of matchedPaths) {
@@ -320,6 +340,7 @@ async function resolvePositivePatterns(opts: {
 export async function matchPaths(opts: {
   patterns: string[];
   fileSystem: FileSystem;
+  candidatePaths?: readonly string[];
   kebabToPascalMap?: Record<string, string>;
   kebabToCamelMap?: Record<string, string>;
   pascalToKebabMap?: Record<string, string>;
@@ -330,6 +351,7 @@ export async function matchPaths(opts: {
   const {
     patterns: rawPatterns,
     fileSystem,
+    candidatePaths,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -337,6 +359,10 @@ export async function matchPaths(opts: {
     camelToPascalMap,
     pascalToCamelMap,
   } = opts;
+
+  if (candidatePaths?.length === 0) {
+    return [];
+  }
 
   const positivePatterns: string[] = [];
   const negativePatterns: string[] = [];
@@ -353,6 +379,7 @@ export async function matchPaths(opts: {
   const positiveResults = await resolvePositivePatterns({
     patterns: positivePatterns,
     fileSystem,
+    candidatePaths,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -366,6 +393,19 @@ export async function matchPaths(opts: {
   }
 
   const negativeGlobs = negativePatterns.map(patternToGlob);
+  if (candidatePaths !== undefined) {
+    const isNegativeMatch = picomatch(negativeGlobs);
+    return positiveResults.filter((result) => {
+      const pathAndAncestors = [result.path];
+      let current = result.path;
+      while (current.includes("/")) {
+        current = current.slice(0, current.lastIndexOf("/"));
+        pathAndAncestors.push(current);
+      }
+      return !pathAndAncestors.some((path) => isNegativeMatch(path));
+    });
+  }
+
   const negatedPaths = await fileSystem.glob(negativeGlobs);
   const excludePaths = negatedPaths.map((p) =>
     p.endsWith("/") ? p.slice(0, -1) : p

--- a/packages/konsistent/src/core/path-selection.test.ts
+++ b/packages/konsistent/src/core/path-selection.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FileSystem } from "./filesystem.js";
+import {
+  createTargetedPathSelection,
+  resolvePathSelectors,
+} from "./path-selection.js";
+
+function createMockFileSystem(opts: {
+  files?: string[];
+  directories?: string[];
+  globResults?: Record<string, string[]>;
+}): FileSystem {
+  const files = new Set(opts.files ?? []);
+  const directories = new Set(opts.directories ?? []);
+  return {
+    fileExists: (path) => files.has(path) || directories.has(path),
+    glob: vi.fn((patterns: string[]) =>
+      Promise.resolve(opts.globResults?.[patterns.join("\0")] ?? [])
+    ),
+    isDirectory: (path) => directories.has(path),
+    isFile: (path) => files.has(path),
+    readDir: () => [],
+    readFile: () => "",
+  };
+}
+
+describe("createTargetedPathSelection", () => {
+  it("adds structural ancestors for selected files", () => {
+    expect(
+      createTargetedPathSelection({
+        selectedPaths: ["components/Button/Button.test.tsx"],
+      })
+    ).toEqual({
+      mode: "targeted",
+      selectedPaths: ["components/Button/Button.test.tsx"],
+      structuralPaths: [
+        ".",
+        "components",
+        "components/Button",
+        "components/Button/Button.test.tsx",
+      ],
+    });
+  });
+});
+
+describe("resolvePathSelectors", () => {
+  it("selects a concrete file without globbing", async () => {
+    const fileSystem = createMockFileSystem({ files: ["src/index.ts"] });
+    const selection = await resolvePathSelectors({
+      selectors: ["src/index.ts"],
+      cwd: "/repo",
+      fileSystem,
+    });
+
+    expect(selection).toMatchObject({
+      mode: "targeted",
+      selectedPaths: ["src/index.ts"],
+    });
+    expect(fileSystem.glob).not.toHaveBeenCalled();
+  });
+
+  it("recursively expands a concrete directory from its bounded root", async () => {
+    const fileSystem = createMockFileSystem({
+      files: ["components/Button/Button.tsx"],
+      directories: ["components/Button"],
+      globResults: {
+        "components/Button/**": ["components/Button/Button.tsx"],
+      },
+    });
+    const selection = await resolvePathSelectors({
+      selectors: ["components/Button"],
+      cwd: "/repo",
+      fileSystem,
+    });
+
+    expect(selection).toMatchObject({
+      mode: "targeted",
+      selectedPaths: ["components/Button", "components/Button/Button.tsx"],
+    });
+    expect(fileSystem.glob).toHaveBeenCalledWith(["components/Button/**"]);
+  });
+
+  it("resolves separate glob roots independently and de-duplicates matches", async () => {
+    const fileSystem = createMockFileSystem({
+      files: ["packages/a/index.ts", "src/index.ts"],
+      globResults: {
+        "packages/a/*.ts": ["packages/a/index.ts"],
+        "src/*.ts": ["src/index.ts", "src/index.ts"],
+      },
+    });
+    const selection = await resolvePathSelectors({
+      selectors: ["packages/a/*.ts", "src/*.ts"],
+      cwd: "/repo",
+      fileSystem,
+    });
+
+    expect(selection).toMatchObject({
+      mode: "targeted",
+      selectedPaths: ["packages/a/index.ts", "src/index.ts"],
+    });
+    expect(fileSystem.glob).toHaveBeenNthCalledWith(1, ["packages/a/*.ts"]);
+    expect(fileSystem.glob).toHaveBeenNthCalledWith(2, ["src/*.ts"]);
+  });
+
+  it("applies negative selectors to the bounded positive matches", async () => {
+    const fileSystem = createMockFileSystem({
+      files: ["components/Button/Button.tsx", "components/Input/Input.tsx"],
+      globResults: {
+        "components/**/*.tsx": [
+          "components/Button/Button.tsx",
+          "components/Input/Input.tsx",
+        ],
+      },
+    });
+    const selection = await resolvePathSelectors({
+      selectors: ["components/**/*.tsx", "!components/Input"],
+      cwd: "/repo",
+      fileSystem,
+    });
+
+    expect(selection).toMatchObject({
+      mode: "targeted",
+      selectedPaths: ["components/Button/Button.tsx"],
+    });
+  });
+
+  it("returns an explicit empty targeted selection", async () => {
+    const selection = await resolvePathSelectors({
+      selectors: ["missing/**/*.ts"],
+      cwd: "/repo",
+      fileSystem: createMockFileSystem({}),
+    });
+
+    expect(selection).toEqual({
+      mode: "targeted",
+      selectedPaths: [],
+      structuralPaths: [],
+    });
+  });
+
+  it("rejects selectors outside cwd and negative-only selections", async () => {
+    const fileSystem = createMockFileSystem({});
+    await expect(
+      resolvePathSelectors({
+        selectors: ["../outside/**/*.ts"],
+        cwd: "/repo",
+        fileSystem,
+      })
+    ).rejects.toThrow("must stay within the current directory");
+    await expect(
+      resolvePathSelectors({
+        selectors: ["!src/**/*.ts"],
+        cwd: "/repo",
+        fileSystem,
+      })
+    ).rejects.toThrow("at least one positive path selector");
+  });
+});

--- a/packages/konsistent/src/core/path-selection.test.ts
+++ b/packages/konsistent/src/core/path-selection.test.ts
@@ -124,6 +124,28 @@ describe("resolvePathSelectors", () => {
     });
   });
 
+  it("applies POSIX character classes in negative selectors", async () => {
+    const fileSystem = createMockFileSystem({
+      files: ["components/Button/Button.tsx", "components/Input/Input.tsx"],
+      globResults: {
+        "components/**/*.tsx": [
+          "components/Button/Button.tsx",
+          "components/Input/Input.tsx",
+        ],
+      },
+    });
+    const selection = await resolvePathSelectors({
+      selectors: ["components/**/*.tsx", "!components/[!B]*/**"],
+      cwd: "/repo",
+      fileSystem,
+    });
+
+    expect(selection).toMatchObject({
+      mode: "targeted",
+      selectedPaths: ["components/Button/Button.tsx"],
+    });
+  });
+
   it("returns an explicit empty targeted selection", async () => {
     const selection = await resolvePathSelectors({
       selectors: ["missing/**/*.ts"],

--- a/packages/konsistent/src/core/path-selection.ts
+++ b/packages/konsistent/src/core/path-selection.ts
@@ -157,7 +157,7 @@ export async function resolvePathSelectors(opts: {
     )
   );
   const negativeMatchers = [...negativeSelectors].map((pattern) => {
-    const matcher = picomatch(pattern);
+    const matcher = picomatch(pattern, { posix: true });
     return (path: string) => matcher(path);
   });
   const selectedPaths = new Set(

--- a/packages/konsistent/src/core/path-selection.ts
+++ b/packages/konsistent/src/core/path-selection.ts
@@ -1,0 +1,171 @@
+import { isAbsolute, posix, relative, resolve, sep } from "node:path";
+import picomatch from "picomatch";
+import { escapePath } from "tinyglobby";
+import type { FileSystem } from "./filesystem.js";
+
+export type PathSelection =
+  | { mode: "all" }
+  | {
+      mode: "targeted";
+      selectedPaths: readonly string[];
+      structuralPaths: readonly string[];
+    };
+
+export const allPathSelection: PathSelection = { mode: "all" };
+
+function normalizePath(opts: { cwd: string; path: string }): string {
+  const absolutePath = isAbsolute(opts.path)
+    ? opts.path
+    : resolve(opts.cwd, opts.path);
+  const relativePath = relative(opts.cwd, absolutePath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Path selector must stay within the current directory: ${opts.path}`
+    );
+  }
+  if (relativePath === "") {
+    return ".";
+  }
+  return relativePath.split(sep).join("/");
+}
+
+function ancestorsOf(path: string): string[] {
+  const ancestors: string[] = [];
+  let current = path;
+  while (current !== ".") {
+    current = posix.dirname(current);
+    ancestors.push(current);
+  }
+  return ancestors;
+}
+
+export function createTargetedPathSelection(opts: {
+  selectedPaths: Iterable<string>;
+}): PathSelection {
+  const selectedPaths = [...new Set(opts.selectedPaths)].sort();
+  const structuralPaths = new Set(selectedPaths);
+  for (const path of selectedPaths) {
+    for (const ancestor of ancestorsOf(path)) {
+      structuralPaths.add(ancestor);
+    }
+  }
+  return {
+    mode: "targeted",
+    selectedPaths,
+    structuralPaths: [...structuralPaths].sort(),
+  };
+}
+
+function expandDirectory(opts: {
+  path: string;
+  fileSystem: FileSystem;
+}): Promise<string[]> {
+  const escapedPath = escapePath(opts.path);
+  return opts.fileSystem.glob([`${escapedPath}/**`]);
+}
+
+async function expandPositiveSelector(opts: {
+  selector: string;
+  fileSystem: FileSystem;
+}): Promise<string[]> {
+  if (opts.fileSystem.isFile(opts.selector)) {
+    return [opts.selector];
+  }
+  if (opts.fileSystem.isDirectory(opts.selector)) {
+    return [
+      opts.selector,
+      ...(await expandDirectory({
+        path: opts.selector,
+        fileSystem: opts.fileSystem,
+      })),
+    ];
+  }
+
+  const matches = await opts.fileSystem.glob([opts.selector]);
+  const directories = matches
+    .filter((path) => opts.fileSystem.isDirectory(path))
+    .sort((left, right) => left.length - right.length)
+    .filter(
+      (path, index, paths) =>
+        !paths.slice(0, index).some((parent) => path.startsWith(`${parent}/`))
+    );
+  const descendants = await Promise.all(
+    directories.map((path) =>
+      expandDirectory({ path, fileSystem: opts.fileSystem })
+    )
+  );
+  return [...matches, ...descendants.flat()];
+}
+
+function isExcluded(opts: {
+  path: string;
+  matchers: Array<(path: string) => boolean>;
+}): boolean {
+  if (opts.matchers.length === 0) {
+    return false;
+  }
+  return [opts.path, ...ancestorsOf(opts.path)].some((path) =>
+    opts.matchers.some((matcher) => matcher(path))
+  );
+}
+
+export async function resolvePathSelectors(opts: {
+  selectors: string[];
+  cwd: string;
+  fileSystem: FileSystem;
+}): Promise<PathSelection> {
+  const positiveSelectors = new Set<string>();
+  const negativeSelectors = new Set<string>();
+
+  for (const rawSelector of opts.selectors) {
+    const normalizedLiteral = normalizePath({
+      cwd: opts.cwd,
+      path: rawSelector,
+    });
+    if (
+      opts.fileSystem.isFile(normalizedLiteral) ||
+      opts.fileSystem.isDirectory(normalizedLiteral)
+    ) {
+      positiveSelectors.add(normalizedLiteral);
+      continue;
+    }
+
+    if (rawSelector.startsWith("!")) {
+      const negativeValue = rawSelector.slice(1);
+      if (negativeValue.length === 0) {
+        throw new Error("Path selector must not be empty");
+      }
+      negativeSelectors.add(
+        normalizePath({ cwd: opts.cwd, path: negativeValue })
+      );
+    } else {
+      positiveSelectors.add(normalizedLiteral);
+    }
+  }
+
+  if (positiveSelectors.size === 0) {
+    throw new Error("--paths requires at least one positive path selector");
+  }
+
+  const matches = await Promise.all(
+    [...positiveSelectors].map((selector) =>
+      expandPositiveSelector({ selector, fileSystem: opts.fileSystem })
+    )
+  );
+  const negativeMatchers = [...negativeSelectors].map((pattern) => {
+    const matcher = picomatch(pattern);
+    return (path: string) => matcher(path);
+  });
+  const selectedPaths = new Set(
+    matches
+      .flat()
+      .map((path) => (path.endsWith("/") ? path.slice(0, -1) : path))
+      .filter((path) => !isExcluded({ path, matchers: negativeMatchers }))
+  );
+
+  return createTargetedPathSelection({ selectedPaths });
+}

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -27,6 +27,57 @@ function createMockFileSystem(opts: {
 }
 
 describe("run", () => {
+  it("bounds ancestor conventions and nested file blocks to selected paths", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          paths: "components/{componentName}",
+          must: [
+            {
+              for: { files: "${componentName}.test.tsx" },
+              must: { exportValues: ["describe"] },
+            },
+          ],
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      directories: new Set(["components/Button", "components/Input"]),
+      files: new Set([
+        "components/Button/Button.test.tsx",
+        "components/Input/Input.test.tsx",
+      ]),
+      fileContents: new Map([
+        ["components/Button/Button.test.tsx", "export const describe = true;"],
+        ["components/Input/Input.test.tsx", "export const invalid = true;"],
+      ]),
+    });
+    const globSpy = vi.spyOn(fs, "glob");
+    const readSpy = vi.spyOn(fs, "readFile");
+
+    const result = await run({
+      config,
+      fileSystem: fs,
+      pathSelection: {
+        mode: "targeted",
+        selectedPaths: ["components/Button/Button.test.tsx"],
+        structuralPaths: [
+          ".",
+          "components",
+          "components/Button",
+          "components/Button/Button.test.tsx",
+        ],
+      },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.filesChecked).toBe(2);
+    expect(globSpy).not.toHaveBeenCalled();
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    expect(readSpy).toHaveBeenCalledWith("components/Button/Button.test.tsx");
+  });
+
   it("returns empty diagnostics for empty conventions", async () => {
     const config: ConfigV1 = { version: "v1", conventions: [] };
     const { diagnostics, filesChecked } = await run({

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -37,6 +37,7 @@ import { createDiagnostic } from "./diagnostics.js";
 import type { FileSystem } from "./filesystem.js";
 import type { MatchedPath } from "./path-matcher.js";
 import { matchPaths } from "./path-matcher.js";
+import type { PathSelection } from "./path-selection.js";
 import { PlaceholderValue } from "./placeholder.js";
 import {
   parsePlaceholderConstraint,
@@ -1109,6 +1110,7 @@ async function evaluateForBlock(opts: {
   fileStructureCache: Map<string, FileStructure>;
   severity?: DiagnosticSeverity;
   checkedPaths: Set<string>;
+  pathSelection?: PathSelection;
   kebabToPascalMap?: Record<string, string>;
   kebabToCamelMap?: Record<string, string>;
   pascalToKebabMap?: Record<string, string>;
@@ -1124,6 +1126,7 @@ async function evaluateForBlock(opts: {
     fileStructureCache,
     severity,
     checkedPaths,
+    pathSelection,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -1167,6 +1170,10 @@ async function evaluateForBlock(opts: {
   const matched = await matchPaths({
     patterns: fullPatterns,
     fileSystem,
+    candidatePaths:
+      pathSelection?.mode === "targeted"
+        ? pathSelection.selectedPaths
+        : undefined,
     kebabToPascalMap,
     kebabToCamelMap,
     pascalToKebabMap,
@@ -1230,9 +1237,10 @@ export interface RunResult {
 export async function run(opts: {
   config: ConfigV1;
   fileSystem: FileSystem;
+  pathSelection?: PathSelection;
 }): Promise<RunResult> {
   const startTime = performance.now();
-  const { config, fileSystem } = opts;
+  const { config, fileSystem, pathSelection } = opts;
   const fileStructureCache = new Map<string, FileStructure>();
 
   const { kebabToPascalMap, kebabToCamelMap } = config;
@@ -1252,6 +1260,10 @@ export async function run(opts: {
       return matchPaths({
         patterns,
         fileSystem,
+        candidatePaths:
+          pathSelection?.mode === "targeted"
+            ? pathSelection.structuralPaths
+            : undefined,
         kebabToPascalMap,
         kebabToCamelMap,
         pascalToKebabMap,
@@ -1327,6 +1339,7 @@ export async function run(opts: {
             fileStructureCache,
             severity,
             checkedPaths,
+            pathSelection,
             kebabToPascalMap,
             kebabToCamelMap,
             pascalToKebabMap,

--- a/packages/konsistent/src/index.ts
+++ b/packages/konsistent/src/index.ts
@@ -20,18 +20,15 @@ const main = defineCommand({
 });
 
 const rawArgs = process.argv.slice(2);
-const hasSubCommand = rawArgs.some(
-  (arg) => !arg.startsWith("-") && SUBCOMMANDS.has(arg)
-);
+const explicitCommand =
+  rawArgs[0] && SUBCOMMANDS.has(rawArgs[0]) ? rawArgs[0] : undefined;
+const hasSubCommand = explicitCommand !== undefined;
 const hasHelpFlag = rawArgs.includes("--help") || rawArgs.includes("-h");
 const hasVersionFlag = rawArgs.length === 1 && rawArgs[0] === "--version";
 
 function getCommandName(): string {
-  const explicit = rawArgs.find(
-    (arg) => !arg.startsWith("-") && SUBCOMMANDS.has(arg)
-  );
-  if (explicit) {
-    return explicit;
+  if (explicitCommand) {
+    return explicitCommand;
   }
   if (hasHelpFlag) {
     return "help";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       picocolors:
         specifier: ^1
         version: 1.1.1
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.5
       resolve.exports:
         specifier: ^2
         version: 2.0.3
@@ -225,6 +228,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.3
       ajv:
         specifier: 'catalog:'
         version: 8.18.0
@@ -894,6 +900,9 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -2287,6 +2296,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/picomatch@4.0.3': {}
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2498,10 +2509,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -2955,8 +2962,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## Pull Request Description

`konsistent` currently checks the entire codebase on every run. This adds targeted execution for explicit paths, staged files, and all modified files while restricting discovery before convention evaluation.

## Relevant technical choices

- Add mutually exclusive `--paths`, `--staged`, and `--modified` CLI modes, with successful warnings for empty selections.
- Preserve full-scan behavior while targeted runs match conventions against a bounded in-memory candidate set, including structural ancestors.
- Use NUL-delimited Git output for staged, unstaged, and non-ignored untracked paths, and process current working-tree content.
- Cover path patterns, Git edge cases, performance boundaries, documentation, and CI hook examples.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
