### PR TITLE
feat(konsistent): allow object properties and array items in constant and type definition schemas to enforce exact TypeScript type references

### DIFF
--- a/.changeset/eight-corners-bet.md
+++ b/.changeset/eight-corners-bet.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): allow object properties and array items in constant and type definition schemas to enforce exact TypeScript type references

--- a/docs/guides/fixing-violations.md
+++ b/docs/guides/fixing-violations.md
@@ -155,7 +155,7 @@ Search first: grep for `X`, case variants, stripped variants (`createX` ↔ `X`,
 
 For `exportConstants`, the value must be a `const`. If a `let` or `function` exists under the right name, conversion to `const` is safe only if there are no reassignments — verify by grepping.
 
-When a constant entry includes `schema`, the constant must also have a matching explicit type annotation. Add or adjust the annotation only after confirming the initializer and all assignments satisfy it. Schema checks support scalar, literal-union enum, homogeneous scalar array, and inline object annotations; they do not infer initializer types or resolve named types. For object schemas, every configured property must be declared. Names in `required` must be non-optional, while other configured names must include `?`.
+When a constant entry includes `schema`, the constant must also have a matching explicit type annotation. Add or adjust the annotation only after confirming the initializer and all assignments satisfy it. Schema checks support scalar, literal-union enum, homogeneous array, and inline object annotations; array items and object properties may require an exact type reference. They do not infer initializer types or resolve referenced types. For object schemas, every configured property must be declared. Names in `required` must be non-optional, while other configured names must include `?`.
 
 #### `exportTypes`
 
@@ -170,7 +170,7 @@ Search first: grep for `X`, case variants, stripped suffixes (`XConfig` ↔ `X` 
   - Type is trivially derivable (e.g., `type FooConfig = Parameters<typeof createFoo>[0]`) and the consumer pattern is obvious from siblings → write the alias.
 - **Non-trivial**: no candidate after search, and the type would require designing a new shape. Defer.
 
-When an entry includes `schema`, inspect the local type alias or interface rather than searching for a re-export. Every configured object property must exist with the exact required/optional status expressed by `required`; unconfigured properties are allowed unless `additionalProperties` is `false`. Do not replace a local schema-constrained type with a cross-file re-export, because `schema` and `from` are mutually exclusive.
+When an entry includes `schema`, inspect the local type alias or interface rather than searching for a re-export. Every configured object property must exist with the exact required/optional status expressed by `required`; configured scalar types and type references must match the annotation exactly. Unconfigured properties are allowed unless `additionalProperties` is `false`. Do not replace a local schema-constrained type with a cross-file re-export, because `schema` and `from` are mutually exclusive.
 
 #### `exportFunctions`
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -253,9 +253,11 @@ exported type.
       "schema": {
         "type": "object",
         "properties": {
+          "auth": { "type": "Readonly<MyAuth>" },
           "model": { "type": "string" },
           "timeout": { "type": "number" }
-        }
+        },
+        "required": ["auth"]
       }
     }
   ]
@@ -323,14 +325,16 @@ The supported `schema` forms are:
 
 - Scalar: `{ "type": "string" }`, using `string`, `number`, `boolean`, or `null`.
 - Enum: `{ "type": "string", "enum": ["a", "b"] }`. The annotation must contain exactly the configured literal values, although their order does not matter.
-- Array: `{ "type": "array", "items": { "type": "string" } }`. Items must use a scalar schema. `T[]`, `Array<T>`, `readonly T[]`, and `ReadonlyArray<T>` annotations qualify.
-- Object: `{ "type": "object", "properties": { ... }, "required": [...], "additionalProperties": false }`. Every configured property must be declared. An empty property schema (`{}`) checks its presence and optionality without constraining its type; a scalar schema also checks its type.
+- Array: `{ "type": "array", "items": { "type": "string" } }`. Items may use a scalar type or a TypeScript type reference such as `MyAuth`, `Namespace.MyAuth`, or `Readonly<MyAuth>`. `T[]`, `Array<T>`, `readonly T[]`, and `ReadonlyArray<T>` annotations qualify.
+- Object: `{ "type": "object", "properties": { ... }, "required": [...], "additionalProperties": false }`. Every configured property must be declared. An empty property schema (`{}`) checks its presence and optionality without constraining its type; a typed schema checks a scalar type or an exact TypeScript type reference.
 
 Object schemas describe TypeScript declaration shapes rather than ordinary JSON Schema instances. Every name in `properties` must exist in the annotation or definition. Names listed in `required` must be non-optional (`name: Type`); all other configured names must be optional (`name?: Type`). `required` defaults to an empty array. `additionalProperties` defaults to `true`, allowing unconfigured TypeScript properties; set it to `false` to reject them.
 
+Inner type references are compared directly to the source annotation without resolving imports or aliases. The comparison includes formatting, so `Readonly<MyAuth>` does not match `Readonly< MyAuth >`. Configured references may contain ASCII letters, digits, spaces, `_`, `$`, `.`, `<`, `>`, and `,`; leading or trailing spaces are rejected.
+
 This is deliberately a strict subset of JSON Schema. Unsupported keywords and shapes are rejected during configuration validation, including `integer`, `$ref`, combinators, nested object or array schemas, tuple schemas, enum array items, schema-valued `additionalProperties`, and constraints such as `minItems`.
 
-Constant schema checks require an explicit annotation on a locally declared constant. Type schema checks require a local type alias or interface definition; interfaces with `extends` are unsupported. Inferred types, named type references, tuples, intersections, index signatures, methods, computed properties, nested types, inherited properties, and cross-file re-exports are not resolved. Enum values and property names inside `schema` are literal data and do not expand placeholders.
+Constant schema checks require an explicit annotation on a locally declared constant. Type schema checks require a local type alias or interface definition; interfaces with `extends` are unsupported. Inferred types, top-level named type references, tuples, intersections, index signatures, methods, computed properties, nested inline types, inherited properties, and cross-file re-exports are not resolved. Enum values and property names inside `schema` are literal data and do not expand placeholders.
 
 ### `exportFunctions`
 

--- a/e2e/fixtures/constant-schemas-broken/konsistent.json
+++ b/e2e/fixtures/constant-schemas-broken/konsistent.json
@@ -6,7 +6,14 @@
       "paths": "src/constants.ts",
       "must": {
         "declareConstants": [
-          { "name": "localPort", "schema": { "type": "number" } }
+          { "name": "localPort", "schema": { "type": "number" } },
+          {
+            "name": "localAuths",
+            "schema": {
+              "type": "array",
+              "items": { "type": "Readonly<MyAuth>" }
+            }
+          }
         ],
         "exportConstants": [
           {
@@ -41,6 +48,17 @@
               "properties": {
                 "metadata": {}
               }
+            }
+          },
+          {
+            "name": "authSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "auth": { "type": "Readonly<MyAuth>" },
+                "modelId": { "type": "string" }
+              },
+              "required": ["auth", "modelId"]
             }
           }
         ]

--- a/e2e/fixtures/constant-schemas-broken/src/constants.ts
+++ b/e2e/fixtures/constant-schemas-broken/src/constants.ts
@@ -1,4 +1,7 @@
+type OtherAuth = { token: string };
+
 const localPort = 3000;
+const localAuths: Readonly<OtherAuth>[] = [];
 
 export const mode: "development" = "development";
 export const tags: number[] = [1];
@@ -7,3 +10,7 @@ export const options: { endpoint: string; retries: number } = {
   retries: 3,
 };
 export const optionalOptions: { metadata: unknown } = { metadata: null };
+export const authSettings: { auth: OtherAuth; modelId: string } = {
+  auth: { token: "secret" },
+  modelId: "model",
+};

--- a/e2e/fixtures/constant-schemas/konsistent.json
+++ b/e2e/fixtures/constant-schemas/konsistent.json
@@ -6,7 +6,14 @@
       "paths": "src/constants.ts",
       "must": {
         "declareConstants": [
-          { "name": "localPort", "schema": { "type": "number" } }
+          { "name": "localPort", "schema": { "type": "number" } },
+          {
+            "name": "localAuths",
+            "schema": {
+              "type": "array",
+              "items": { "type": "Readonly<MyAuth>" }
+            }
+          }
         ],
         "exportConstants": [
           {
@@ -42,6 +49,17 @@
               "properties": {
                 "metadata": {}
               }
+            }
+          },
+          {
+            "name": "authSettings",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "auth": { "type": "Readonly<MyAuth>" },
+                "modelId": { "type": "string" }
+              },
+              "required": ["auth", "modelId"]
             }
           }
         ]

--- a/e2e/fixtures/constant-schemas/src/constants.ts
+++ b/e2e/fixtures/constant-schemas/src/constants.ts
@@ -1,4 +1,7 @@
+type MyAuth = { token: string };
+
 const localPort: number = 3000;
+const localAuths: ReadonlyArray<Readonly<MyAuth>> = [];
 
 export const mode: "development" | "production" = "development";
 export const tags: readonly string[] = ["stable"];
@@ -6,3 +9,10 @@ export const options: { endpoint: string; metadata?: unknown } = {
   endpoint: "https://example.com",
 };
 export const optionalOptions: { metadata?: unknown } = {};
+export const authSettings: {
+  auth: Readonly<MyAuth>;
+  modelId: string;
+} = {
+  auth: { token: "secret" },
+  modelId: "model",
+};

--- a/e2e/fixtures/type-schemas-broken/konsistent.json
+++ b/e2e/fixtures/type-schemas-broken/konsistent.json
@@ -11,7 +11,8 @@
             "schema": {
               "type": "object",
               "properties": {
-                "enabled": { "type": "boolean" }
+                "enabled": { "type": "boolean" },
+                "auth": { "type": "Readonly<MyAuth>" }
               }
             }
           }

--- a/e2e/fixtures/type-schemas-broken/src/types.ts
+++ b/e2e/fixtures/type-schemas-broken/src/types.ts
@@ -1,5 +1,8 @@
+type OtherAuth = { token: string };
+
 type InternalSettings = {
   enabled?: boolean;
+  auth?: Readonly<OtherAuth>;
 };
 
 export type ModuleSettings = {

--- a/e2e/fixtures/type-schemas/konsistent.json
+++ b/e2e/fixtures/type-schemas/konsistent.json
@@ -11,7 +11,8 @@
             "schema": {
               "type": "object",
               "properties": {
-                "enabled": { "type": "boolean" }
+                "enabled": { "type": "boolean" },
+                "auth": { "type": "Readonly<MyAuth>" }
               }
             }
           }

--- a/e2e/fixtures/type-schemas/src/types.ts
+++ b/e2e/fixtures/type-schemas/src/types.ts
@@ -1,5 +1,8 @@
+type MyAuth = { token: string };
+
 type InternalSettings = {
   enabled?: boolean;
+  auth?: Readonly<MyAuth>;
 };
 
 export type ModuleSettings = {

--- a/e2e/new-predicates.test.ts
+++ b/e2e/new-predicates.test.ts
@@ -70,6 +70,9 @@ describe("constant-schemas-broken fixture", () => {
         'Constant "localPort" must have an explicit type annotation'
       );
       expect(error.stdout).toContain(
+        'Constant "localAuths" must be an array with items of type "Readonly<MyAuth>"'
+      );
+      expect(error.stdout).toContain(
         'Constant "mode" must have exactly the configured enum values'
       );
       expect(error.stdout).toContain(
@@ -80,6 +83,9 @@ describe("constant-schemas-broken fixture", () => {
       );
       expect(error.stdout).toContain(
         'Constant "optionalOptions" property "metadata" must be optional'
+      );
+      expect(error.stdout).toContain(
+        'Constant "authSettings" property "auth" must be of type "Readonly<MyAuth>"'
       );
     }
   });
@@ -105,6 +111,9 @@ describe("type-schemas-broken fixture", () => {
       expect(error.code ?? error.status).toBe(1);
       expect(error.stdout).toContain(
         'Type "ModuleSettings" must define property "timeout"'
+      );
+      expect(error.stdout).toContain(
+        'Type "InternalSettings" property "auth" must be of type "Readonly<MyAuth>"'
       );
       expect(error.stdout).toContain("type-schemas");
     }

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -163,12 +163,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -202,12 +197,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -317,12 +307,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -356,12 +341,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -662,12 +642,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": ["type"],
@@ -701,12 +676,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": ["type"],
@@ -837,12 +807,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -876,12 +841,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -1302,12 +1262,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -1341,12 +1296,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -1456,12 +1406,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -1495,12 +1440,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -1801,12 +1741,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": ["type"],
@@ -1840,12 +1775,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": ["type"],
@@ -1976,12 +1906,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -2015,12 +1940,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -2522,12 +2442,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -2561,12 +2476,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -2676,12 +2586,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -2715,12 +2620,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -3021,12 +2921,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": ["type"],
@@ -3060,12 +2955,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": ["type"],
@@ -3196,12 +3086,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -3235,12 +3120,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -3661,12 +3541,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -3700,12 +3575,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -3815,12 +3685,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -3854,12 +3719,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],
@@ -4160,12 +4020,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": ["type"],
@@ -4199,12 +4054,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": ["type"],
@@ -4335,12 +4185,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": ["type"],
@@ -4374,12 +4219,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": ["type"],

--- a/packages/convention/src/constant-schema.test.ts
+++ b/packages/convention/src/constant-schema.test.ts
@@ -10,10 +10,12 @@ describe("ConstantValueSchemaV1Schema", () => {
     { type: "string" },
     { type: "number", enum: [1, 2] },
     { type: "array", items: { type: "boolean" } },
+    { type: "array", items: { type: "ReadonlyArray<MyType>" } },
     {
       type: "object",
       properties: {
         name: { type: "string" },
+        auth: { type: "Readonly<MyAuth>" },
         metadata: {},
       },
       required: ["name"],
@@ -29,12 +31,17 @@ describe("ConstantValueSchemaV1Schema", () => {
     { type: "string", enum: ["a", "a"] },
     { type: "string", enum: ["a", 1] },
     { type: "array" },
-    { type: "array", items: { type: "object" } },
     { type: "array", items: { type: "string", enum: ["a"] } },
     { type: "array", items: { type: "string" }, minItems: 1 },
+    { type: "array", items: { type: "" } },
+    { type: "array", items: { type: " MyType" } },
+    { type: "array", items: { type: "MyType " } },
+    { type: "array", items: { type: "MyType\t" } },
+    { type: "array", items: { type: "MyType | null" } },
+    { type: "array", items: { type: "MyType[]" } },
     {
       type: "object",
-      properties: { child: { type: "object" } },
+      properties: { child: { type: "MyType & OtherType" } },
     },
     {
       type: "object",
@@ -52,6 +59,7 @@ describe("ConstantValueSchemaV1Schema", () => {
       additionalProperties: { type: "string" },
     },
     { type: "string", oneOf: [{ type: "string" }] },
+    { type: "MyType" },
   ])("rejects unsupported schema %#", (schema) => {
     expect(ConstantValueSchemaV1Schema.safeParse(schema).success).toBe(false);
   });

--- a/packages/convention/src/constant-schema.ts
+++ b/packages/convention/src/constant-schema.ts
@@ -18,6 +18,14 @@ export const ConstantScalarSchemaV1Schema = z.strictObject({
   type: ConstantScalarTypeV1Schema,
 });
 
+const ConstantInnerTypeV1Schema = z
+  .string()
+  .regex(/^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$/);
+
+const ConstantInnerTypeSchemaV1Schema = z.strictObject({
+  type: ConstantInnerTypeV1Schema,
+});
+
 export const ConstantEnumSchemaV1Schema = z
   .strictObject({
     type: ConstantScalarTypeV1Schema,
@@ -50,12 +58,12 @@ export const ConstantEnumSchemaV1Schema = z
 
 const ConstantObjectPropertySchemaV1Schema = z.union([
   z.strictObject({}),
-  ConstantScalarSchemaV1Schema,
+  ConstantInnerTypeSchemaV1Schema,
 ]);
 
 export const ConstantArraySchemaV1Schema = z.strictObject({
   type: z.literal("array"),
-  items: ConstantScalarSchemaV1Schema,
+  items: ConstantInnerTypeSchemaV1Schema,
 });
 
 export const ConstantObjectSchemaV1Schema = z

--- a/packages/convention/src/generated-schema.test.ts
+++ b/packages/convention/src/generated-schema.test.ts
@@ -71,7 +71,12 @@ describe("reusable-convention-package.schema.json", () => {
             exportTypes: [
               {
                 name: "LocalSettings",
-                schema: { type: "object", properties: {} },
+                schema: {
+                  type: "object",
+                  properties: {
+                    auth: { type: "Readonly<MyAuth>" },
+                  },
+                },
               },
               { name: "SharedSettings", from: "./settings" },
             ],
@@ -80,6 +85,30 @@ describe("reusable-convention-package.schema.json", () => {
       ],
     });
     expect(valid).toBe(true);
+  });
+
+  it("rejects invalid characters in inner type references", () => {
+    const valid = validate({
+      conventionSpecVersion: "v1",
+      conventions: [
+        {
+          name: "settings",
+          description: "Settings exports.",
+          must: {
+            exportTypes: [
+              {
+                name: "Settings",
+                schema: {
+                  type: "object",
+                  properties: { auth: { type: "MyAuth | null" } },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(false);
   });
 
   it("accepts aliases for current value and type symbol predicates", () => {

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -221,12 +221,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -265,12 +260,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -392,12 +382,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -436,12 +421,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -770,12 +750,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -814,12 +789,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -965,12 +935,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -1009,12 +974,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -1468,12 +1428,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -1512,12 +1467,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -1639,12 +1589,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -1683,12 +1628,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -2017,12 +1957,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -2061,12 +1996,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -2212,12 +2142,7 @@
                                       "properties": {
                                         "type": {
                                           "type": "string",
-                                          "enum": [
-                                            "string",
-                                            "number",
-                                            "boolean",
-                                            "null"
-                                          ]
+                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                         }
                                       },
                                       "required": [
@@ -2256,12 +2181,7 @@
                                             "properties": {
                                               "type": {
                                                 "type": "string",
-                                                "enum": [
-                                                  "string",
-                                                  "number",
-                                                  "boolean",
-                                                  "null"
-                                                ]
+                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                               }
                                             },
                                             "required": [
@@ -2773,12 +2693,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -2817,12 +2732,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -2944,12 +2854,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -2988,12 +2893,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -3322,12 +3222,7 @@
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": [
-                                                        "string",
-                                                        "number",
-                                                        "boolean",
-                                                        "null"
-                                                      ]
+                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                     }
                                                   },
                                                   "required": [
@@ -3366,12 +3261,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -3517,12 +3407,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -3561,12 +3446,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -4096,12 +3976,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -4140,12 +4015,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -4267,12 +4137,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -4311,12 +4176,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -4645,12 +4505,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -4689,12 +4544,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -4840,12 +4690,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -4884,12 +4729,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -5343,12 +5183,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -5387,12 +5222,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -5514,12 +5344,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -5558,12 +5383,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -5892,12 +5712,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -5936,12 +5751,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -6087,12 +5897,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -6131,12 +5936,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -6662,12 +6462,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -6706,12 +6501,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -6833,12 +6623,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -6877,12 +6662,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -7211,12 +6991,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -7255,12 +7030,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -7406,12 +7176,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -7450,12 +7215,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -7909,12 +7669,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -7953,12 +7708,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -8080,12 +7830,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -8124,12 +7869,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -8458,12 +8198,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -8502,12 +8237,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -8653,12 +8383,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -8697,12 +8422,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -9234,12 +8954,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -9278,12 +8993,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -9405,12 +9115,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -9449,12 +9154,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -9783,12 +9483,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -9827,12 +9522,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -9978,12 +9668,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -10022,12 +9707,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -10481,12 +10161,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -10525,12 +10200,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -10652,12 +10322,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -10696,12 +10361,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -11030,12 +10690,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -11074,12 +10729,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -11225,12 +10875,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -11269,12 +10914,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -11739,12 +11379,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -11783,12 +11418,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -11910,12 +11540,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -11954,12 +11579,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -12288,12 +11908,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -12332,12 +11947,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -12483,12 +12093,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -12527,12 +12132,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -13043,12 +12643,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -13087,12 +12682,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -13214,12 +12804,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -13258,12 +12843,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -13592,12 +13172,7 @@
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "enum": [
-                                                        "string",
-                                                        "number",
-                                                        "boolean",
-                                                        "null"
-                                                      ]
+                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                     }
                                                   },
                                                   "required": [
@@ -13636,12 +13211,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -13787,12 +13357,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -13831,12 +13396,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -14366,12 +13926,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -14410,12 +13965,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -14537,12 +14087,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -14581,12 +14126,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -14915,12 +14455,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -14959,12 +14494,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -15110,12 +14640,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -15154,12 +14679,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -15613,12 +15133,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -15657,12 +15172,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -15784,12 +15294,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -15828,12 +15333,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -16162,12 +15662,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -16206,12 +15701,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -16357,12 +15847,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -16401,12 +15886,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -16932,12 +16412,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -16976,12 +16451,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -17103,12 +16573,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -17147,12 +16612,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -17481,12 +16941,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -17525,12 +16980,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -17676,12 +17126,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -17720,12 +17165,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -18179,12 +17619,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -18223,12 +17658,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -18350,12 +17780,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -18394,12 +17819,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -18728,12 +18148,7 @@
                                                                 "properties": {
                                                                   "type": {
                                                                     "type": "string",
-                                                                    "enum": [
-                                                                      "string",
-                                                                      "number",
-                                                                      "boolean",
-                                                                      "null"
-                                                                    ]
+                                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                   }
                                                                 },
                                                                 "required": [
@@ -18772,12 +18187,7 @@
                                                                       "properties": {
                                                                         "type": {
                                                                           "type": "string",
-                                                                          "enum": [
-                                                                            "string",
-                                                                            "number",
-                                                                            "boolean",
-                                                                            "null"
-                                                                          ]
+                                                                          "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                         }
                                                                       },
                                                                       "required": [
@@ -18923,12 +18333,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -18967,12 +18372,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -19504,12 +18904,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -19548,12 +18943,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -19675,12 +19065,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -19719,12 +19104,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -20053,12 +19433,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -20097,12 +19472,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -20248,12 +19618,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -20292,12 +19657,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -20751,12 +20111,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -20795,12 +20150,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -20922,12 +20272,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -20966,12 +20311,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -21300,12 +20640,7 @@
                                                             "properties": {
                                                               "type": {
                                                                 "type": "string",
-                                                                "enum": [
-                                                                  "string",
-                                                                  "number",
-                                                                  "boolean",
-                                                                  "null"
-                                                                ]
+                                                                "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                               }
                                                             },
                                                             "required": [
@@ -21344,12 +20679,7 @@
                                                                   "properties": {
                                                                     "type": {
                                                                       "type": "string",
-                                                                      "enum": [
-                                                                        "string",
-                                                                        "number",
-                                                                        "boolean",
-                                                                        "null"
-                                                                      ]
+                                                                      "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                     }
                                                                   },
                                                                   "required": [
@@ -21495,12 +20825,7 @@
                                                         "properties": {
                                                           "type": {
                                                             "type": "string",
-                                                            "enum": [
-                                                              "string",
-                                                              "number",
-                                                              "boolean",
-                                                              "null"
-                                                            ]
+                                                            "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                           }
                                                         },
                                                         "required": [
@@ -21539,12 +20864,7 @@
                                                               "properties": {
                                                                 "type": {
                                                                   "type": "string",
-                                                                  "enum": [
-                                                                    "string",
-                                                                    "number",
-                                                                    "boolean",
-                                                                    "null"
-                                                                  ]
+                                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                                 }
                                                               },
                                                               "required": [
@@ -22009,12 +21329,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -22053,12 +21368,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -22180,12 +21490,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -22224,12 +21529,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [
@@ -22558,12 +21858,7 @@
                                               "properties": {
                                                 "type": {
                                                   "type": "string",
-                                                  "enum": [
-                                                    "string",
-                                                    "number",
-                                                    "boolean",
-                                                    "null"
-                                                  ]
+                                                  "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                 }
                                               },
                                               "required": [
@@ -22602,12 +21897,7 @@
                                                     "properties": {
                                                       "type": {
                                                         "type": "string",
-                                                        "enum": [
-                                                          "string",
-                                                          "number",
-                                                          "boolean",
-                                                          "null"
-                                                        ]
+                                                        "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                       }
                                                     },
                                                     "required": [
@@ -22753,12 +22043,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "string",
-                                                "number",
-                                                "boolean",
-                                                "null"
-                                              ]
+                                              "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                             }
                                           },
                                           "required": [
@@ -22797,12 +22082,7 @@
                                                 "properties": {
                                                   "type": {
                                                     "type": "string",
-                                                    "enum": [
-                                                      "string",
-                                                      "number",
-                                                      "boolean",
-                                                      "null"
-                                                    ]
+                                                    "pattern": "^[A-Za-z0-9_$.,<>]+(?: +[A-Za-z0-9_$.,<>]+)*$"
                                                   }
                                                 },
                                                 "required": [

--- a/packages/konsistent/scripts/generate-schema.test.ts
+++ b/packages/konsistent/scripts/generate-schema.test.ts
@@ -155,4 +155,27 @@ describe("konsistent.schema.json", () => {
     });
     expect(valid).toBe(false);
   });
+
+  it("rejects invalid characters in inner type references", () => {
+    const valid = validate({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/settings.ts",
+          must: {
+            exportTypes: [
+              {
+                name: "Settings",
+                schema: {
+                  type: "object",
+                  properties: { auth: { type: "MyAuth | null" } },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(valid).toBe(false);
+  });
 });

--- a/packages/konsistent/src/typescript/constant-type-schema.test.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.test.ts
@@ -110,6 +110,35 @@ describe("constant type schemas", () => {
     ).toBe(false);
   });
 
+  it.each([
+    { annotation: "MyType[]", itemType: "MyType" },
+    { annotation: "Array<Namespace.MyType>", itemType: "Namespace.MyType" },
+    {
+      annotation: "readonly Readonly<MyType>[]",
+      itemType: "Readonly<MyType>",
+    },
+    {
+      annotation: "ReadonlyArray<ReadonlyMap<Key, Value>>",
+      itemType: "ReadonlyMap<Key, Value>",
+    },
+  ])("matches an array containing type references for $annotation", (entry) => {
+    expect(
+      matches({
+        type: entry.annotation,
+        schema: { type: "array", items: { type: entry.itemType } },
+      })
+    ).toBe(true);
+  });
+
+  it("compares array item type references exactly", () => {
+    expect(
+      matches({
+        type: "Array<Readonly< MyType >>",
+        schema: { type: "array", items: { type: "Readonly<MyType>" } },
+      })
+    ).toBe(false);
+  });
+
   it("matches required, optional, typed, and unconstrained properties", () => {
     expect(
       matches({
@@ -126,6 +155,53 @@ describe("constant type schemas", () => {
         },
       })
     ).toBe(true);
+  });
+
+  it("matches exact type references on object properties", () => {
+    expect(
+      matches({
+        type: "{ auth: Readonly<MyAuth>; modelId: string }",
+        schema: {
+          type: "object",
+          properties: {
+            auth: { type: "Readonly<MyAuth>" },
+            modelId: { type: "string" },
+          },
+          required: ["auth", "modelId"],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("compares object property type references exactly", () => {
+    expect(
+      matches({
+        type: "{ auth: Readonly< MyAuth > }",
+        schema: {
+          type: "object",
+          properties: { auth: { type: "Readonly<MyAuth>" } },
+          required: ["auth"],
+        },
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    "object",
+    "MyAuth | null",
+    "[MyAuth]",
+    "{ id: string }",
+  ])("rejects unsupported object property type %s", (type) => {
+    expect(
+      matches({
+        type: `{ auth: ${type} }`,
+        schema: {
+          type: "object",
+          properties: { auth: { type: "MyAuth" } },
+          required: ["auth"],
+        },
+      })
+    ).toBe(false);
   });
 
   it("matches quoted empty property names", () => {
@@ -271,6 +347,19 @@ describe("type definition schemas", () => {
         properties: { enabled: { type: "boolean" } },
       },
       source: "interface Settings { enabled?: boolean }",
+    });
+    expect(result).toEqual({ matches: true });
+  });
+
+  it("matches type references in a type definition", () => {
+    const result = matchDefinition({
+      name: "Settings",
+      schema: {
+        type: "object",
+        properties: { auth: { type: "Readonly<MyAuth>" } },
+        required: ["auth"],
+      },
+      source: "type Settings = { auth: Readonly<MyAuth> }",
     });
     expect(result).toEqual({ matches: true });
   });

--- a/packages/konsistent/src/typescript/constant-type-schema.ts
+++ b/packages/konsistent/src/typescript/constant-type-schema.ts
@@ -18,14 +18,14 @@ interface ConstantEnumTypeInfo {
 }
 
 interface ConstantArrayTypeInfo {
-  itemType: ConstantScalarTypeV1;
+  itemType: string;
   kind: "array";
 }
 
 interface ConstantObjectPropertyTypeInfo {
   name: string;
   optional: boolean;
-  scalarType?: ConstantScalarTypeV1;
+  type?: string;
 }
 
 interface ConstantObjectTypeInfo {
@@ -130,7 +130,7 @@ function parseEnumType(node: ts.TypeNode): ConstantEnumTypeInfo | undefined {
 
 function parseArrayType(node: ts.TypeNode): ConstantArrayTypeInfo | undefined {
   if (ts.isArrayTypeNode(node)) {
-    const itemType = parseScalarType(node.elementType);
+    const itemType = parseInnerType(node.elementType);
     return itemType ? { kind: "array", itemType } : undefined;
   }
 
@@ -139,7 +139,7 @@ function parseArrayType(node: ts.TypeNode): ConstantArrayTypeInfo | undefined {
     node.operator === ts.SyntaxKind.ReadonlyKeyword &&
     ts.isArrayTypeNode(node.type)
   ) {
-    const itemType = parseScalarType(node.type.elementType);
+    const itemType = parseInnerType(node.type.elementType);
     return itemType ? { kind: "array", itemType } : undefined;
   }
 
@@ -149,12 +149,19 @@ function parseArrayType(node: ts.TypeNode): ConstantArrayTypeInfo | undefined {
       (name === "Array" || name === "ReadonlyArray") &&
       node.typeArguments?.length === 1
     ) {
-      const itemType = parseScalarType(node.typeArguments[0]);
+      const itemType = parseInnerType(node.typeArguments[0]);
       return itemType ? { kind: "array", itemType } : undefined;
     }
   }
 
   return;
+}
+
+function parseInnerType(node: ts.TypeNode | undefined): string | undefined {
+  if (!(node && (parseScalarType(node) || ts.isTypeReferenceNode(node)))) {
+    return;
+  }
+  return node.getText();
 }
 
 function getPropertyName(name: ts.PropertyName): string | undefined {
@@ -180,11 +187,11 @@ function parseObjectType(opts: {
       return;
     }
     names.add(name);
-    const scalarType = parseScalarType(member.type);
+    const type = parseInnerType(member.type);
     properties.push({
       name,
       optional: Boolean(member.questionToken),
-      ...(scalarType ? { scalarType } : {}),
+      ...(type ? { type } : {}),
     });
   }
 
@@ -310,7 +317,7 @@ function matchObjectSchema(opts: {
     }
     if (
       Object.hasOwn(propertySchema, "type") &&
-      property.scalarType !== propertySchema.type
+      property.type !== propertySchema.type
     ) {
       return {
         matches: false,

--- a/packages/konsistent/src/typescript/parser.test.ts
+++ b/packages/konsistent/src/typescript/parser.test.ts
@@ -426,7 +426,7 @@ describe("parseFileStructure", () => {
         extends: [],
         typeInfo: {
           kind: "object",
-          properties: [{ name: "bar", optional: false, scalarType: "string" }],
+          properties: [{ name: "bar", optional: false, type: "string" }],
         },
       });
     });
@@ -650,8 +650,8 @@ describe("parseFileStructure", () => {
         typeInfo: {
           kind: "object",
           properties: [
-            { name: "model", optional: true, scalarType: "string" },
-            { name: "timeout", optional: false, scalarType: "number" },
+            { name: "model", optional: true, type: "string" },
+            { name: "timeout", optional: false, type: "number" },
           ],
         },
       });

--- a/packages/konsistent/src/typescript/predicates/declare-constants.test.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-constants.test.ts
@@ -63,6 +63,25 @@ describe("checkDeclareConstants", () => {
     expect(result).toEqual([]);
   });
 
+  it("validates type references in a configured array schema", () => {
+    const result = checkDeclareConstants({
+      expected: [
+        {
+          name: "authProviders",
+          schema: {
+            type: "array",
+            items: { type: "Readonly<MyAuth>" },
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseSource({
+        source: "const authProviders: ReadonlyArray<Readonly<MyAuth>> = [];",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
   it("reports a mismatched constant schema", () => {
     const result = checkDeclareConstants({
       expected: [{ name: "port", schema: { type: "number" } }],

--- a/packages/konsistent/src/typescript/predicates/declare-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/declare-types.test.ts
@@ -68,7 +68,10 @@ describe("checkDeclareTypes", () => {
           name: "Options",
           schema: {
             type: "object",
-            properties: { enabled: { type: "boolean" } },
+            properties: {
+              enabled: { type: "boolean" },
+              auth: { type: "Namespace.MyAuth" },
+            },
           },
         },
       ],
@@ -76,7 +79,7 @@ describe("checkDeclareTypes", () => {
       fileStructure: parseSource({
         source: [
           "type Settings = { model?: string; extra?: number };",
-          "interface Options { enabled?: boolean }",
+          "interface Options { enabled?: boolean; auth?: Namespace.MyAuth }",
         ].join("\n"),
       }),
     });

--- a/packages/konsistent/src/typescript/predicates/export-constants.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-constants.test.ts
@@ -193,6 +193,27 @@ describe("checkExportConstants", () => {
     expect(result).toEqual([]);
   });
 
+  it("validates type references in an object schema", () => {
+    const result = checkExportConstants({
+      expected: [
+        {
+          name: "settings",
+          schema: {
+            type: "object",
+            properties: { auth: { type: "Readonly<MyAuth>" } },
+            required: ["auth"],
+          },
+        },
+      ],
+      context: createMockContext({ path: "src/index.ts" }),
+      fileStructure: parseFileStructure({
+        source:
+          "export const settings: { auth: Readonly<MyAuth> } = { auth: {} };",
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+
   it("reports an object schema mismatch", () => {
     const result = checkExportConstants({
       expected: [

--- a/packages/konsistent/src/typescript/predicates/export-types.test.ts
+++ b/packages/konsistent/src/typescript/predicates/export-types.test.ts
@@ -340,6 +340,7 @@ describe("checkExportTypes", () => {
             properties: {
               model: { type: "string" },
               timeout: { type: "number" },
+              providers: { type: "ReadonlyArray<ModelProvider>" },
             },
           },
         },
@@ -350,6 +351,7 @@ describe("checkExportTypes", () => {
           export type ModuleSettings = {
             model?: string;
             timeout?: number;
+            providers?: ReadonlyArray<ModelProvider>;
             reasoning?: "low" | "medium" | "high";
           };
         `,


### PR DESCRIPTION
## Pull Request Description

Schema rules for object properties and array items currently support only scalar types. This adds exact TypeScript type-reference matching for constant annotations and local type definitions.

## Relevant technical choices

- Accept type references such as `MyAuth`, `Namespace.MyAuth`, and `Readonly<MyAuth>` for object properties and array items.
- Compare configured references directly against TypeScript AST text without resolving aliases or imports.
- Validate configured references with a restricted character allowlist while preserving existing scalar and required-property behavior.
- Regenerate the published JSON Schemas and cover passing and failing behavior with unit and e2e tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
