### PR TITLE
fix(konsistent): fix top-level reusable convention `if` conditions

### DIFF
--- a/.changeset/fuzzy-hounds-rule.md
+++ b/.changeset/fuzzy-hounds-rule.md
@@ -1,0 +1,5 @@
+---
+"konsistent": patch
+---
+
+fix(konsistent): fix top-level reusable convention `if` conditions

--- a/docs/guides/authoring-reusable-conventions.md
+++ b/docs/guides/authoring-reusable-conventions.md
@@ -97,6 +97,8 @@ A reusable convention has the same fields as a hand-written one with two adjustm
 - `name` and `description` are **required** (consumers see them in error messages and source listings).
 - `must` and `mustNot` must use the **flat object form** (`MustPredicates`). The `MustBlock[]` form is not allowed in reusable conventions — see [Restrictions](../reference/reusable-conventions.md#restrictions).
 - `paths` is **optional**. Omit it to force consumers to supply `paths` at the use-site (which is useful when the right pattern depends on the consuming project's layout). When `paths` is omitted, consumers can only reference the convention via the `use` form.
+- `if` is optional. At the top level it gates the complete expanded convention separately for every matched path, and consumers using the object form can replace it with another complete condition. The same field gates one block when the convention is referenced inside a parent's `must[]`.
+- `for` only applies when the convention is referenced inside a parent's `must[]`; top-level references do not carry it into the resolved convention.
 
 ## 3. Build and verify
 

--- a/docs/reference/conditional-rules.md
+++ b/docs/reference/conditional-rules.md
@@ -1,6 +1,22 @@
 # Conditional rules
 
-When a convention's `must` is an **array** of blocks instead of a single object, each block can have its own conditions, scope, and predicates. This unlocks rules like "story files must export `meta`" or "test files must import the project's custom render helper" — structural conventions that linters and the type checker won't catch on their own.
+An `if` condition can gate either a block inside a convention's `must` array or an entire reusable convention referenced at the top level. This unlocks rules like "story files must export `meta`" or "test files must import the project's custom render helper" — structural conventions that linters and the type checker won't catch on their own.
+
+## Top-level conditions on reusable references
+
+A reusable convention can declare `if`, and a top-level object reference can override it:
+
+```json
+{
+  "use": "common/conditionally-require-tests",
+  "paths": "packages/{packageName}",
+  "if": { "hasFile": "${packageName}.test.ts" }
+}
+```
+
+For each path matched by `paths`, the condition is resolved with that path's placeholders and evaluated independently. A non-match skips every `must` and `mustNot` predicate or block for that path. A match continues with normal predicate execution, including each block's own `if` and `for` behavior. The use-site `if` replaces an inherited condition as one complete object rather than merging condition properties.
+
+This top-level form is specific to reusable-convention references; hand-written conventions continue to put conditions inside `must` blocks. See [Reusable conventions](./reusable-conventions.md).
 
 ## Object form vs. array form
 
@@ -68,7 +84,7 @@ Switch from object to array form when you need:
 
 ## `if.hasFile`
 
-Block applies only when the named file exists at (or relative to) the matched path. Templates are resolved using the parent placeholders.
+The condition matches only when the named file exists at (or relative to) the matched path. Templates are resolved using the matched path's placeholders.
 
 ```json
 {
@@ -87,11 +103,11 @@ For `components/Button`, the block runs only if `components/Button/index.test.ts
 
 ## `if.placeholderSatisfies`
 
-Block applies only when the named placeholder satisfies a constraint. Syntax, constraint catalog, and examples in [constraints.md](./constraints.md#ifplaceholdersatisfies).
+The condition matches only when the named placeholder satisfies a constraint. Syntax, constraint catalog, and examples are in [constraints.md](./constraints.md#ifplaceholdersatisfies).
 
 ## Import conditions
 
-Import conditions inspect the file at the matched `paths` entry. They return false when the matched path is a directory. Conditions run before `for.files`, so they always inspect the parent matched path rather than files selected by `for`.
+Import conditions inspect the file at the matched `paths` entry. They return false when the matched path is a directory. A block-level condition runs before `for.files`, so it always inspects the parent matched path rather than files selected by `for`. Parsing is shared with block conditions and TypeScript predicates for the same file.
 
 | Condition | Value | Applies when |
 | --- | --- | --- |
@@ -133,7 +149,7 @@ Value and type imports remain separate:
 
 Only static ES import declarations count. Re-exports, dynamic `import()`, `require()`, and TypeScript import-equals do not.
 
-An `if` block has exactly **one** condition property — not multiple and not an empty object.
+An `if` condition has exactly **one** condition property — not multiple and not an empty object.
 
 ## `for.files`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,6 +61,8 @@ A convention is a rule that says "files matching `paths` must satisfy `must` and
 
 The configuration is `strict` — unknown fields cause a validation error. Run `konsistent validate` to catch typos.
 
+Hand-written conventions do not accept a top-level `if`. Top-level `if` is available on reusable-convention string and object references: an inherited or use-site condition gates the entire expanded convention for each matched path. See [Top-level conditions on reusable references](./conditional-rules.md#top-level-conditions-on-reusable-references).
+
 ## `must`: predicates or blocks
 
 `must` accepts two shapes.

--- a/docs/reference/reusable-conventions.md
+++ b/docs/reference/reusable-conventions.md
@@ -43,7 +43,7 @@ Each entry of `conventions[]` is one of three shapes. The first two are new for 
 
 ### String reference
 
-A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. The reusable convention must declare its own `paths` — string references cannot supply them. If the convention has no `paths`, `konsistent` fails at config load and tells you to switch to the `use` form.
+A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. The reusable convention must declare its own `paths` — string references cannot supply them. If the convention has no `paths`, `konsistent` fails at config load and tells you to switch to the `use` form. An inherited `if` condition is also preserved and evaluated for each path matched by the reusable convention.
 
 ```json
 {
@@ -59,7 +59,7 @@ A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. T
 
 ### Object reference (`use` form)
 
-`{ "use": "<vendor>/<name>", ...overrides }` references a reusable convention and overlays your overrides on top of it. The override fields available are `paths`, `placeholders`, `excludeFiles`, `severity`, `if`, `for`, `must`, and `mustNot` — the same optional fields a hand-written convention has, minus `name` and `description` (which come from the source).
+`{ "use": "<vendor>/<name>", ...overrides }` references a reusable convention and overlays your overrides on top of it. The top-level override fields are `paths`, `placeholders`, `excludeFiles`, `severity`, `if`, `must`, and `mustNot`; `name` and `description` come from the source. `for` is only available when the reference appears inside a parent's `must[]`.
 
 Use this form when the reusable convention has no `paths` (so you must supply them) or when you want to adjust a field for your project.
 
@@ -94,6 +94,18 @@ When a reusable convention's `must` references a placeholder (e.g. `${providerId
 
 See [Static placeholder values](./path-patterns.md#static-placeholder-values) for the full rules.
 
+An `if` declared by the reusable convention is inherited by both string and object references. An object reference can replace it with a project-specific condition:
+
+```json
+{
+  "use": "common/conditionally-require-tests",
+  "paths": "packages/{packageName}",
+  "if": { "hasFile": "${packageName}.spec.ts" }
+}
+```
+
+The condition is evaluated separately for every matched path. A non-match skips the expanded convention's complete `must` and `mustNot` work for that path. A match continues into its predicates and any block-level conditions. See [Conditional rules](./conditional-rules.md#top-level-conditions-on-reusable-references).
+
 ### Hand-written convention
 
 Any entry that is neither a string nor has a `use` key is treated as a hand-written `Convention` and validated against the existing schema. See [configuration.md](./configuration.md). You can mix all three forms in the same `conventions[]` array.
@@ -123,7 +135,7 @@ A hand-written convention whose `must` is a `MustBlock[]` may also reference a r
 
 Allowed override keys at this nesting level are every field a hand-written `MustBlock` exposes — `name`, `description`, `if`, `for`, `excludeFiles`, `must`, and `mustNot`. Top-level-only fields (`paths`, `severity`) are not accepted at the use-site, and the referenced reusable convention must not declare them either: a reusable that ships `paths` or `severity` can only be referenced from the top level of `conventions[]`. Authors who want their reusable to be usable in both contexts should publish it without those fields.
 
-Override merge follows the same rules as the top-level `use` form: arrays replace, primitives replace, and `must`/`mustNot` deep-merge with the inherited predicates.
+Override merge follows the same rules as the top-level `use` form: arrays and conditions replace, primitives replace, and `must`/`mustNot` deep-merge with the inherited predicates.
 
 ## Merge semantics
 
@@ -132,6 +144,7 @@ When you write `{ use: "<vendor>/<name>", ...overrides }`, `konsistent` deep-mer
 | Field kind | Rule |
 | --- | --- |
 | Plain object (e.g. `must`, `mustNot`, nested predicate definitions) | Recursive deep-merge. Keys you supply replace the inherited value; keys you omit pass through. |
+| `if` condition object | The complete use-site condition replaces the inherited condition. Condition properties are never combined. |
 | Array (e.g. `paths`, `excludeFiles`, predicate lists like `haveFiles`, `declareFunctions`, `exportValues`, `exportFunctions`) | Your array fully replaces the inherited array. Use `"excludeFiles": []` to clear an inherited list. |
 | Primitive (e.g. `severity`, `description`) | Your value replaces the inherited value. |
 
@@ -185,13 +198,14 @@ Note that `excludeFiles` was fully replaced (array-replace), while `must` was de
 ## Restrictions
 
 - **Reusable conventions only support object-form `must` and `mustNot`.** They cannot ship the `MustBlock[]` form. This keeps override semantics predictable — you always know the merge target is a flat predicate object. Your own hand-written conventions can still use `MustBlock[]` in `must`; `mustNot` is object-form only everywhere. See [predicates.md](./predicates.md).
+- **Top-level `for` is not supported.** A reusable convention's `for` field is available when it expands into a block inside a parent's `must[]`; it is not carried into a top-level string or object reference.
 - **The `conventionSources` value is a single string.** No object form (`{ package: ... }` / `{ path: ... }`) — auto-detection by leading `.` / `/` is unambiguous.
 - **No cross-source merging.** Two `conventionSources` entries cannot be merged into a single prefix. If two packages happen to ship a convention with the same name, your vendor prefix scopes them.
 - **`MustBlock[]` cannot be introduced via override.** Because the source convention's `must` is always object-form, deep-merge keeps the result object-form.
 
 ## Placeholder validation
 
-After expansion, `konsistent` walks every string inside each merged convention's `must` and `mustNot` and checks that each `${placeholder}` referenced is declared as `{placeholder}` in at least one `paths` entry. This catches mismatches between a reusable convention's templates and the `paths` you supplied at the use-site, before any file is scanned.
+After expansion, `konsistent` walks every string inside each merged convention's `if`, `must`, and `mustNot` and checks that each `${placeholder}` referenced is declared as `{placeholder}` in at least one `paths` entry or in `placeholders`. This includes inherited and overridden conditions, and catches mismatches before any file is scanned.
 
 ## Error reference
 
@@ -209,7 +223,7 @@ All errors below are returned from `loadConfig()` as `{ success: false, error }`
 | npm source missing exports condition | `Convention source "<prefix>" → "<specifier>": package does not declare an exports["./konsistent"] entry.` | The source package isn't a reusable-convention package; check the spelling or pick a different source. |
 | Reusable-convention package fails schema validation | `Convention source "<prefix>" → "<specifier>": invalid reusable-convention package at <path>: <issues>` | The author shipped an invalid package; report upstream. |
 | Empty source value | `Convention source "<prefix>" has empty value.` | Supply a path or npm specifier. |
-| Placeholder used in `must` or `mustNot` but not declared in `paths` or `placeholders` | `Convention "<identifier>" references "${<placeholder>}" in <key>, but neither paths nor placeholders declare "{<placeholder>}".` | Either declare the placeholder in `paths` or `placeholders`, or remove the unresolved template. |
+| Placeholder used in `if`, `must`, or `mustNot` but not declared in `paths` or `placeholders` | `Convention "<identifier>" references "${<placeholder>}" in <key>, but neither paths nor placeholders declare "{<placeholder>}".` | Either declare the placeholder in `paths` or `placeholders`, or remove the unresolved template. |
 | `use` inside `must[]` points at a reusable that declares `paths`/`severity` | `Convention "<prefix>/<name>" referenced in conventions[<i>].must[<j>] declares top-level-only field(s) "<field>". Such conventions can only be referenced at the top level of conventions[]. Either remove the field(s) from the source convention, or move the reference out of must[].` | Drop `paths`/`severity` from the reusable, or reference it directly from `conventions[]`. |
 
 `<identifier>` in the placeholder error is the convention's `name`, the `<vendor>/<name>` reference, or `conventions[<i>]` — whichever was available.
@@ -218,4 +232,4 @@ All errors below are returned from `loadConfig()` as `{ success: false, error }`
 
 - [Authoring reusable conventions](../guides/authoring-reusable-conventions.md) — publish your own.
 - [konsistent.json reference](./configuration.md) — the surrounding config shape.
-- [Path patterns](./path-patterns.md) — placeholder syntax used in `paths`, `must`, and `mustNot`.
+- [Path patterns](./path-patterns.md) — placeholder syntax used in `paths`, `if`, `must`, and `mustNot`.

--- a/e2e/fixtures/reusable-convention-top-level-if/konsistent.json
+++ b/e2e/fixtures/reusable-convention-top-level-if/konsistent.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "conventionSources": {
+    "common": "./local-conventions.json"
+  },
+  "conventions": [
+    {
+      "use": "common/conditionally-require-file",
+      "if": { "hasFile": "gate.ts" }
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-top-level-if/local-conventions.json
+++ b/e2e/fixtures/reusable-convention-top-level-if/local-conventions.json
@@ -1,0 +1,14 @@
+{
+  "conventionSpecVersion": "v1",
+  "conventions": [
+    {
+      "name": "conditionally-require-file",
+      "description": "Matching directories must contain required.ts.",
+      "paths": "src/{caseName}",
+      "if": { "hasFile": "inherited-gate.ts" },
+      "must": {
+        "haveFiles": ["required.ts"]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/reusable-convention-top-level-if/src/matching/gate.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/matching/gate.ts
@@ -1,0 +1,1 @@
+export const gate = true;

--- a/e2e/fixtures/reusable-convention-top-level-if/src/skipped/inherited-gate.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/skipped/inherited-gate.ts
@@ -1,0 +1,1 @@
+export const inheritedGate = true;

--- a/e2e/reusable-conventions.test.ts
+++ b/e2e/reusable-conventions.test.ts
@@ -94,6 +94,35 @@ describe("reusable-convention-object-ref-broken fixture", () => {
   });
 });
 
+describe("reusable-convention-top-level-if fixture", () => {
+  const cwd = resolve(fixturesDir, "reusable-convention-top-level-if");
+
+  it("runs a matching top-level use condition and skips non-matching paths", async () => {
+    try {
+      await runCli({ args: ["check"], cwd });
+      expect.fail("Expected check to exit with code 1");
+    } catch (err: unknown) {
+      const error = err as {
+        stdout: string;
+        stderr: string;
+        code: number;
+        status: number;
+      };
+      expect(error.code ?? error.status).toBe(1);
+      expect(error.stdout).toContain("Missing required file");
+      expect(error.stdout).toContain("required.ts");
+      expect(error.stdout).toContain("src/matching");
+      expect(error.stdout).not.toContain("src/skipped");
+      expect(error.stdout).toContain("Found 1 error.");
+    }
+  });
+
+  it("validates the top-level condition override", async () => {
+    const { stdout } = await runCli({ args: ["validate"], cwd });
+    expect(stdout).toContain("Configuration is valid");
+  });
+});
+
 describe("reusable-convention-must-block-ref fixture", () => {
   const cwd = resolve(fixturesDir, "reusable-convention-must-block-ref");
 

--- a/packages/konsistent/scripts/generate-schema.test.ts
+++ b/packages/konsistent/scripts/generate-schema.test.ts
@@ -128,6 +128,22 @@ describe("konsistent.schema.json", () => {
     expect(valid).toBe(true);
   });
 
+  it("accepts a condition on a top-level use reference", () => {
+    const valid = validate({
+      version: "v1",
+      conventionSources: { common: "./conventions.json" },
+      conventions: [
+        {
+          use: "common/conditional-rule",
+          paths: "src/*.ts",
+          if: { hasFile: "test.ts" },
+        },
+      ],
+    });
+
+    expect(valid).toBe(true);
+  });
+
   it("rejects aliases in import conditions", () => {
     const valid = validate({
       version: "v1",

--- a/packages/konsistent/src/config/placeholder-validator.ts
+++ b/packages/konsistent/src/config/placeholder-validator.ts
@@ -1,4 +1,9 @@
-import type { ConventionV1, MustBlockV1, MustPredicatesV1 } from "./schema.js";
+import type {
+  ConventionV1,
+  IfConditionV1,
+  MustBlockV1,
+  MustPredicatesV1,
+} from "./schema.js";
 
 const USAGE_REGEX = /\$\{([a-zA-Z][a-zA-Z0-9]*)/g;
 const DECLARATION_REGEX =
@@ -36,11 +41,7 @@ export function validatePlaceholders(opts: {
       }
     }
 
-    const usages = collectUsagesInAssertions({
-      must: convention.must,
-      mustNot: convention.mustNot,
-      declaredOuter: declared,
-    });
+    const usages = collectUsagesInConvention({ convention, declared });
 
     const reported = new Set<string>();
     for (const usage of usages) {
@@ -87,16 +88,42 @@ interface Usage {
   name: string;
 }
 
+function collectUsagesInConvention(opts: {
+  convention: ConventionV1;
+  declared: Set<string>;
+}): Usage[] {
+  const { convention, declared } = opts;
+  const usages: Usage[] = [];
+  if (convention.if) {
+    collectUsagesInCondition({
+      condition: convention.if,
+      prefix: "",
+      declared,
+      usages,
+    });
+  }
+  usages.push(
+    ...collectUsagesInAssertions({
+      must: convention.must,
+      mustNot: convention.mustNot,
+      declaredOuter: declared,
+    })
+  );
+  return usages;
+}
+
 function collectUsagesInCondition(opts: {
-  condition: NonNullable<MustBlockV1["if"]>;
+  condition: IfConditionV1;
+  prefix: string;
   declared: Set<string>;
   usages: Usage[];
 }): void {
-  const { condition, declared, usages } = opts;
+  const { condition, prefix, declared, usages } = opts;
+  const keyPrefix = prefix ? `${prefix}.if` : "if";
   if (Object.hasOwn(condition, "hasFile")) {
     pushStringUsages({
       value: (condition as { hasFile: string }).hasFile,
-      key: "must.if.hasFile",
+      key: `${keyPrefix}.hasFile`,
       declared,
       usages,
     });
@@ -104,7 +131,7 @@ function collectUsagesInCondition(opts: {
     pushStringUsages({
       value: (condition as { placeholderSatisfies: string })
         .placeholderSatisfies,
-      key: "must.if.placeholderSatisfies",
+      key: `${keyPrefix}.placeholderSatisfies`,
       declared,
       usages,
     });
@@ -117,7 +144,7 @@ function collectUsagesInCondition(opts: {
           }
         ).hasValueImport,
       ],
-      key: "must.if.hasValueImport",
+      key: `${keyPrefix}.hasValueImport`,
       objectFields: ["name", "from"],
       declared,
       usages,
@@ -131,7 +158,7 @@ function collectUsagesInCondition(opts: {
           }
         ).hasTypeImport,
       ],
-      key: "must.if.hasTypeImport",
+      key: `${keyPrefix}.hasTypeImport`,
       objectFields: ["name", "from"],
       declared,
       usages,
@@ -139,14 +166,14 @@ function collectUsagesInCondition(opts: {
   } else if (Object.hasOwn(condition, "hasValueImportFrom")) {
     pushStringUsages({
       value: (condition as { hasValueImportFrom: string }).hasValueImportFrom,
-      key: "must.if.hasValueImportFrom",
+      key: `${keyPrefix}.hasValueImportFrom`,
       declared,
       usages,
     });
   } else if (Object.hasOwn(condition, "hasTypeImportFrom")) {
     pushStringUsages({
       value: (condition as { hasTypeImportFrom: string }).hasTypeImportFrom,
-      key: "must.if.hasTypeImportFrom",
+      key: `${keyPrefix}.hasTypeImportFrom`,
       declared,
       usages,
     });
@@ -208,6 +235,7 @@ function collectUsagesInBlock(opts: {
   if (block.if) {
     collectUsagesInCondition({
       condition: block.if,
+      prefix: "must",
       declared: declaredHere,
       usages,
     });

--- a/packages/konsistent/src/config/reference-expander.test.ts
+++ b/packages/konsistent/src/config/reference-expander.test.ts
@@ -1,5 +1,6 @@
 import type { ReusableConventionV1 } from "@konsistent/convention";
 import { describe, expect, it } from "vitest";
+import { validatePlaceholders } from "./placeholder-validator.js";
 import { expandReferences } from "./reference-expander.js";
 import type { ConventionV1 } from "./schema.js";
 import type { SourceMap } from "./source-resolver.js";
@@ -67,6 +68,32 @@ describe("expandReferences", () => {
     if (result.success) {
       expect(result.conventions[0]?.mustNot).toEqual({
         exportConstants: ["debug"],
+      });
+    }
+  });
+
+  it("preserves an inherited condition on a string reference", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "conditional-string",
+          description: "Runs only for matching packages.",
+          paths: "packages/{packageName}",
+          if: { hasFile: "${packageName}.test.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const result = expandReferences({
+      conventions: ["common/conditional-string"],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.conventions[0]?.if).toEqual({
+        hasFile: "${packageName}.test.ts",
       });
     }
   });
@@ -274,6 +301,110 @@ describe("expandReferences", () => {
       expect(result.conventions[0]?.placeholders).toEqual({
         providerId: "openai",
       });
+    }
+  });
+
+  it("preserves an inherited condition on an object reference", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "conditional-object",
+          description: "Runs only when a marker exists.",
+          if: { hasFile: "marker.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const result = expandReferences({
+      conventions: [
+        {
+          use: "common/conditional-object",
+          paths: "packages/*",
+        },
+      ],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.conventions[0]?.if).toEqual({ hasFile: "marker.ts" });
+    }
+  });
+
+  it("replaces an inherited condition with the complete use-site condition", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "conditional-override",
+          description: "Uses a consumer-specific gate.",
+          paths: "packages/{packageName}",
+          if: { hasFile: "inherited-marker.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const result = expandReferences({
+      conventions: [
+        {
+          use: "common/conditional-override",
+          if: {
+            placeholderSatisfies: "packageName:matches(^public-)",
+          },
+        },
+      ],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.conventions[0]?.if).toEqual({
+        placeholderSatisfies: "packageName:matches(^public-)",
+      });
+    }
+  });
+
+  it("validates placeholders in inherited and overridden conditions", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "conditional-placeholders",
+          description: "Uses condition placeholders.",
+          paths: "packages/*",
+          if: { hasFile: "${missingInherited}.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const expansionResult = expandReferences({
+      conventions: [
+        "common/conditional-placeholders",
+        {
+          use: "common/conditional-placeholders",
+          if: { hasValueImportFrom: "${missingOverride}" },
+        },
+      ],
+      sourceMap,
+    });
+
+    expect(expansionResult.success).toBe(true);
+    if (expansionResult.success) {
+      const validationResult = validatePlaceholders({
+        conventions: expansionResult.conventions,
+        identifiers: expansionResult.identifiers,
+      });
+
+      expect(validationResult.ok).toBe(false);
+      if (!validationResult.ok) {
+        expect(validationResult.error).toContain(
+          'references "${missingInherited}" in if.hasFile'
+        );
+        expect(validationResult.error).toContain(
+          'references "${missingOverride}" in if.hasValueImportFrom'
+        );
+      }
     }
   });
 
@@ -691,6 +822,46 @@ describe("expandReferences", () => {
           name: "needs-readme",
           description: "Block requiring a README.md.",
           must: { haveFiles: ["README.md"] },
+        });
+      }
+    }
+  });
+
+  it("preserves and atomically overrides conditions for a nested use ref", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "conditional-block",
+          description: "Conditionally requires an index.",
+          if: { hasFile: "inherited-marker.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const handWritten = {
+      paths: "packages/{packageName}",
+      must: [
+        "common/conditional-block",
+        {
+          use: "common/conditional-block",
+          if: { placeholderSatisfies: "packageName:segments(1)" },
+        },
+      ],
+    } as Parameters<typeof expandReferences>[0]["conventions"][number];
+
+    const result = expandReferences({
+      conventions: [handWritten],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const must = result.conventions[0]?.must;
+      if (Array.isArray(must)) {
+        expect(must[0]?.if).toEqual({ hasFile: "inherited-marker.ts" });
+        expect(must[1]?.if).toEqual({
+          placeholderSatisfies: "packageName:segments(1)",
         });
       }
     }

--- a/packages/konsistent/src/config/reference-expander.ts
+++ b/packages/konsistent/src/config/reference-expander.ts
@@ -200,7 +200,7 @@ function expandMustBlockReference(opts: {
     base.excludeFiles = reusable.excludeFiles;
   }
 
-  const merged = deepMerge({ base, override: overrides });
+  const merged = mergeReferenceOverrides({ base, overrides });
 
   const validated = MustBlockV1Schema.safeParse(merged);
   if (!validated.success) {
@@ -301,6 +301,9 @@ function expandStringReference(opts: {
   if (reusable.excludeFiles !== undefined) {
     candidate.excludeFiles = reusable.excludeFiles;
   }
+  if (reusable.if !== undefined) {
+    candidate.if = reusable.if;
+  }
 
   const validated = ConventionV1Schema.safeParse(candidate);
   if (!validated.success) {
@@ -362,8 +365,11 @@ function expandUseReference(opts: {
   if (reusable.excludeFiles !== undefined) {
     base.excludeFiles = reusable.excludeFiles;
   }
+  if (reusable.if !== undefined) {
+    base.if = reusable.if;
+  }
 
-  const merged = deepMerge({ base, override: overrides });
+  const merged = mergeReferenceOverrides({ base, overrides });
 
   const validated = ConventionV1Schema.safeParse(merged);
   if (!validated.success) {
@@ -389,6 +395,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     !Array.isArray(value) &&
     Object.getPrototypeOf(value) === Object.prototype
   );
+}
+
+function mergeReferenceOverrides(opts: {
+  base: Record<string, unknown>;
+  overrides: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { base, overrides } = opts;
+  const merged = deepMerge({ base, override: overrides });
+  if (Object.hasOwn(overrides, "if")) {
+    merged.if = overrides.if;
+  }
+  return merged;
 }
 
 function deepMerge(opts: {

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ConfigV1Schema } from "./schema.js";
+import { ConfigV1Schema, ConventionV1Schema } from "./schema.js";
 
 describe("ConfigV1Schema", () => {
   it("accepts a minimal valid config with empty conventions", () => {
@@ -16,6 +16,46 @@ describe("ConfigV1Schema", () => {
       version: "v1",
       conventions: [],
     });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a condition on a top-level use reference", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          use: "common/conditional-rule",
+          paths: "src/*.ts",
+          if: { hasFile: "test.ts" },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("keeps top-level conditions unavailable to hand-written conventions", () => {
+    const result = ConfigV1Schema.safeParse({
+      version: "v1",
+      conventions: [
+        {
+          paths: "src/*.ts",
+          if: { hasFile: "test.ts" },
+          must: { haveType: "file" },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a top-level condition in the resolved convention schema", () => {
+    const result = ConventionV1Schema.safeParse({
+      paths: "src/*.ts",
+      if: { hasFile: "test.ts" },
+      must: { haveType: "file" },
+    });
+
     expect(result.success).toBe(true);
   });
 

--- a/packages/konsistent/src/config/schema.ts
+++ b/packages/konsistent/src/config/schema.ts
@@ -83,6 +83,7 @@ const ConventionV1Shape = {
   excludeFiles: z.array(z.string()).optional(),
   paths: z.union([z.string(), z.array(z.string())]),
   placeholders: PlaceholdersMapSchema.optional(),
+  if: IfConditionV1Schema.optional(),
 };
 
 export const ConventionV1Schema = z.union([

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ConfigV1 } from "../config/schema.js";
+import type { ConfigV1, IfConditionV1 } from "../config/schema.js";
 import type { FileSystem } from "./filesystem.js";
 import { run } from "./runner.js";
 
@@ -743,6 +743,58 @@ describe("run", () => {
     expect(diagnostics[0].conventionName).toBe("conditional-rule");
   });
 
+  it("evaluates a top-level condition per matched path and gates every block", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          name: "conditional-convention",
+          paths: "packages/{packageName}",
+          if: { hasFile: "gate.ts" },
+          must: [
+            {
+              name: "matching-block-condition",
+              if: { hasFile: "block-gate.ts" },
+              must: { haveFiles: ["required.ts"] },
+            },
+            {
+              name: "non-matching-block-condition",
+              if: { hasFile: "absent.ts" },
+              must: { haveFiles: ["also-required.ts"] },
+            },
+            {
+              name: "gated-must-not",
+              mustNot: { haveType: "directory" },
+            },
+          ],
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([
+        ["packages/*", ["packages/matching", "packages/non-matching"]],
+      ]),
+      directories: new Set(["packages/matching", "packages/non-matching"]),
+      files: new Set([
+        "packages/matching/gate.ts",
+        "packages/matching/block-gate.ts",
+        "packages/non-matching/block-gate.ts",
+      ]),
+    });
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.filePath)).toEqual([
+      "packages/matching",
+      "packages/matching",
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.conventionName)).toEqual([
+      "matching-block-condition",
+      "gated-must-not",
+    ]);
+  });
+
   it("skips must block when if.hasFile condition is not met", async () => {
     const config: ConfigV1 = {
       version: "v1",
@@ -1067,6 +1119,47 @@ describe("run", () => {
     const { diagnostics } = await run({ config, fileSystem: fs });
 
     expect(diagnostics).toHaveLength(2);
+    expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports every condition at the top level and reuses parsed files", async () => {
+    const conditions: IfConditionV1[] = [
+      { hasFile: "marker.ts" },
+      { placeholderSatisfies: "moduleName:matches(^client$)" },
+      {
+        hasValueImport: {
+          name: "create${moduleName.toPascalCase()}",
+          from: "./${moduleName}",
+        },
+      },
+      { hasValueImportFrom: "./${moduleName}" },
+      { hasTypeImport: { name: "${moduleName.toPascalCase()}" } },
+      { hasTypeImportFrom: "./${moduleName}" },
+    ];
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: conditions.map((condition, index) => ({
+        name: `top-level-condition-${index}`,
+        paths: "src/{moduleName}.ts",
+        if: condition,
+        must: { exportConstants: [`missing${index}`] },
+      })),
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/*.ts", ["src/client.ts"]]]),
+      files: new Set(["src/client.ts", "src/marker.ts"]),
+      fileContents: new Map([
+        [
+          "src/client.ts",
+          'import { createClient, type Client } from "./client";',
+        ],
+      ]),
+    });
+    const readSpy = vi.spyOn(fs, "readFile");
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+
+    expect(diagnostics).toHaveLength(conditions.length);
     expect(readSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -5,6 +5,7 @@ import {
 } from "@konsistent/convention";
 import type {
   ConfigV1,
+  IfConditionV1,
   ImportDefinitionV1,
   MustBlockV1,
   MustPredicatesV1,
@@ -238,24 +239,24 @@ function evaluatePlaceholderSatisfies(opts: {
 }
 
 function evaluateCondition(opts: {
-  block: MustBlockV1;
+  condition: IfConditionV1 | undefined;
   context: PredicateContext;
   fileSystem: FileSystem;
   fileStructureCache: Map<string, FileStructure>;
 }): boolean {
-  const { block, context, fileSystem, fileStructureCache } = opts;
-  if (!block.if) {
+  const { condition, context, fileSystem, fileStructureCache } = opts;
+  if (!condition) {
     return true;
   }
-  if (Object.hasOwn(block.if, "hasFile")) {
+  if (Object.hasOwn(condition, "hasFile")) {
     const resolvedPath = context.resolveTemplate(
-      (block.if as { hasFile: string }).hasFile
+      (condition as { hasFile: string }).hasFile
     );
     return context.fileExists(resolvedPath);
   }
-  if (Object.hasOwn(block.if, "placeholderSatisfies")) {
+  if (Object.hasOwn(condition, "placeholderSatisfies")) {
     return evaluatePlaceholderSatisfies({
-      raw: (block.if as { placeholderSatisfies: string }).placeholderSatisfies,
+      raw: (condition as { placeholderSatisfies: string }).placeholderSatisfies,
       context,
     });
   }
@@ -269,34 +270,35 @@ function evaluateCondition(opts: {
     cache: fileStructureCache,
   });
 
-  if (Object.hasOwn(block.if, "hasValueImport")) {
+  if (Object.hasOwn(condition, "hasValueImport")) {
     return hasImport({
-      expected: (block.if as { hasValueImport: string | ImportDefinitionV1 })
+      expected: (condition as { hasValueImport: string | ImportDefinitionV1 })
         .hasValueImport,
       importKind: "value",
       context,
       fileStructure,
     });
   }
-  if (Object.hasOwn(block.if, "hasTypeImport")) {
+  if (Object.hasOwn(condition, "hasTypeImport")) {
     return hasImport({
-      expected: (block.if as { hasTypeImport: string | ImportDefinitionV1 })
+      expected: (condition as { hasTypeImport: string | ImportDefinitionV1 })
         .hasTypeImport,
       importKind: "type",
       context,
       fileStructure,
     });
   }
-  if (Object.hasOwn(block.if, "hasValueImportFrom")) {
+  if (Object.hasOwn(condition, "hasValueImportFrom")) {
     return hasImportFrom({
-      expected: (block.if as { hasValueImportFrom: string }).hasValueImportFrom,
+      expected: (condition as { hasValueImportFrom: string })
+        .hasValueImportFrom,
       importKind: "value",
       context,
       fileStructure,
     });
   }
   return hasImportFrom({
-    expected: (block.if as { hasTypeImportFrom: string }).hasTypeImportFrom,
+    expected: (condition as { hasTypeImportFrom: string }).hasTypeImportFrom,
     importKind: "type",
     context,
     fileStructure,
@@ -1376,10 +1378,21 @@ export async function run(opts: {
         continue;
       }
 
+      if (
+        !evaluateCondition({
+          condition: convention.if,
+          context,
+          fileSystem,
+          fileStructureCache,
+        })
+      ) {
+        continue;
+      }
+
       for (const block of blocks) {
         if (
           !evaluateCondition({
-            block,
+            condition: block.if,
             context,
             fileSystem,
             fileStructureCache,


### PR DESCRIPTION
## Pull Request Description

Top-level reusable convention references accepted `if` in the input schema, but inherited conditions were dropped and use-site conditions failed resolved validation. This makes those conditions gate the complete expanded convention for each matched path.

- Preserve inherited `if` conditions for string and object references.
- Replace inherited conditions atomically with use-site overrides.
- Reuse condition evaluation and parsed-file caching across convention and block scopes.
- Validate condition placeholders and cover the behavior with unit, schema, and CLI e2e tests.

## Relevant technical choices

Hand-written top-level conventions remain unchanged, and top-level `for` behavior is intentionally out of scope. Existing nested `use` conditions continue through the same shared evaluator.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
