### PR TITLE
feat(konsistent): add negative conditional rules with `ifNot`

### DIFF
--- a/.changeset/bright-ravens-check.md
+++ b/.changeset/bright-ravens-check.md
@@ -1,0 +1,6 @@
+---
+"@konsistent/convention": patch
+"konsistent": patch
+---
+
+feat(konsistent): add negative conditional rules with `ifNot`

--- a/docs/guides/authoring-reusable-conventions.md
+++ b/docs/guides/authoring-reusable-conventions.md
@@ -97,7 +97,7 @@ A reusable convention has the same fields as a hand-written one with two adjustm
 - `name` and `description` are **required** (consumers see them in error messages and source listings).
 - `must` and `mustNot` must use the **flat object form** (`MustPredicates`). The `MustBlock[]` form is not allowed in reusable conventions — see [Restrictions](../reference/reusable-conventions.md#restrictions).
 - `paths` is **optional**. Omit it to force consumers to supply `paths` at the use-site (which is useful when the right pattern depends on the consuming project's layout). When `paths` is omitted, consumers can only reference the convention via the `use` form.
-- `if` is optional. At the top level it gates the complete expanded convention separately for every matched path, and consumers using the object form can replace it with another complete condition. The same field gates one block when the convention is referenced inside a parent's `must[]`.
+- `if` and `ifNot` are optional and accept the same condition object. At the top level they gate the complete expanded convention separately for every matched path, and consumers using the object form can replace either complete condition. The same fields gate one block when the convention is referenced inside a parent's `must[]`.
 - `for` only applies when the convention is referenced inside a parent's `must[]`; top-level references do not carry it into the resolved convention.
 
 ## 3. Build and verify

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -246,7 +246,9 @@ Apply predicates only when the matched file imports a particular value, type, or
 }
 ```
 
-Use `hasValueImport` or `hasTypeImport` to check one imported symbol. Use `hasValueImportFrom` or `hasTypeImportFrom` to check whether any import of that kind comes from an exact module source. See [conditional-rules.md](../reference/conditional-rules.md#import-conditions).
+Use `hasValueImport` or `hasTypeImport` to check one imported symbol. Use `hasValueImportFrom` or `hasTypeImportFrom` to check whether any import of that kind comes from an exact module source. See [conditional-rules.md](../reference/conditional-rules.md#import-predicates).
+
+Put any of these same condition objects under `ifNot` to apply predicates only when the import is absent. `ifNot` always uses the same condition catalog and matching behavior as `if`.
 
 ## Iterating over file patterns
 

--- a/docs/guides/exploring-codebases.md
+++ b/docs/guides/exploring-codebases.md
@@ -90,7 +90,7 @@ This is the [`from`](../reference/predicates.md#exportvalues) field on `exportVa
 
 ### Conditional patterns
 
-Some files exist only in some entries (test files, story files). When they exist, do they follow conventions that the test framework or type checker can't enforce? These become [`if`](../reference/conditional-rules.md#ifhasfile) / [`for`](../reference/conditional-rules.md#forfiles) blocks:
+Some files exist only in some entries (test files, story files). When they exist—or when another feature is absent—do they follow conventions that the test framework or type checker can't enforce? These become [`if` and `ifNot`](../reference/conditional-rules.md#positive-and-negative-gates) / [`for`](../reference/conditional-rules.md#forfiles) blocks:
 
 - If `.stories.tsx` files exist, do they always export a `meta` constant? (Storybook needs it; the type checker doesn't enforce.)
 - If a `.test.tsx` file exists, does it import the project's custom render or test-context helper? (Project convention; lint rules don't know about it.)
@@ -154,5 +154,6 @@ For every pattern you identify:
 - Optional file conditions → `if.hasFile` blocks.
 - Subset-only rules → `if.placeholderSatisfies` with a `matches` or `segments` constraint.
 - Import-dependent rules → `if.hasValueImport`, `if.hasValueImportFrom`, `if.hasTypeImport`, or `if.hasTypeImportFrom` blocks.
+- Negative conditions → use the same condition under `ifNot`; it supports every condition available to `if`.
 
 See [examples.md](./examples.md) for ready-made templates of each shape, and [predicates.md](../reference/predicates.md) for the full predicate catalog.

--- a/docs/guides/fixing-violations.md
+++ b/docs/guides/fixing-violations.md
@@ -66,7 +66,7 @@ The options:
 
 When "change the rule" admits more than one specific shape, surface the sub-options instead of collapsing them. Examples worth considering:
 - File-naming variants: `${name}-options.ts` vs. `${name}-model-options.ts`.
-- A **hybrid** rule that splits by a sub-pattern (e.g., "single-word providers ending in `ai` use flat-case; everything else uses camelCase") — encodable via [case maps](../reference/case-maps.md) or [`placeholderSatisfies`](../reference/conditional-rules.md#ifplaceholdersatisfies) constraints.
+- A **hybrid** rule that splits by a sub-pattern (e.g., "single-word providers ending in `ai` use flat-case; everything else uses camelCase") — encodable via [case maps](../reference/case-maps.md) or [`placeholderSatisfies`](../reference/conditional-rules.md#placeholdersatisfies) constraints.
 - Mixed-severity (`error` for must-have, `warning` for nice-to-have).
 
 For low-count rules, assume the code is wrong and skip ahead.
@@ -79,7 +79,7 @@ Apply config changes from step 3. Validate after every edit:
 pnpm konsistent validate
 ```
 
-See [configuration.md](../reference/configuration.md) for the full schema, [predicates.md](../reference/predicates.md) for the predicate catalog, and [conditional-rules.md](../reference/conditional-rules.md) for `if`/`for` blocks.
+See [configuration.md](../reference/configuration.md) for the full schema, [predicates.md](../reference/predicates.md) for the predicate catalog, and [conditional-rules.md](../reference/conditional-rules.md) for `if`/`ifNot`/`for` blocks.
 
 ## 5. Re-run and confirm
 

--- a/docs/reference/conditional-rules.md
+++ b/docs/reference/conditional-rules.md
@@ -1,22 +1,34 @@
 # Conditional rules
 
-An `if` condition can gate either a block inside a convention's `must` array or an entire reusable convention referenced at the top level. This unlocks rules like "story files must export `meta`" or "test files must import the project's custom render helper" — structural conventions that linters and the type checker won't catch on their own.
+`if` and `ifNot` conditions can gate either a block inside a convention's `must` array or an entire reusable convention referenced at the top level. This unlocks rules like "story files must export `meta`" or "test files must import the project's custom render helper" — structural conventions that linters and the type checker won't catch on their own.
 
 ## Top-level conditions on reusable references
 
-A reusable convention can declare `if`, and a top-level object reference can override it:
+A reusable convention can declare `if`, `ifNot`, or both, and a top-level object reference can override either condition:
 
 ```json
 {
   "use": "common/conditionally-require-tests",
   "paths": "packages/{packageName}",
-  "if": { "hasFile": "${packageName}.test.ts" }
+  "if": { "hasFile": "${packageName}.test.ts" },
+  "ifNot": { "hasFile": "skip-tests.ts" }
 }
 ```
 
-For each path matched by `paths`, the condition is resolved with that path's placeholders and evaluated independently. A non-match skips every `must` and `mustNot` predicate or block for that path. A match continues with normal predicate execution, including each block's own `if` and `for` behavior. The use-site `if` replaces an inherited condition as one complete object rather than merging condition properties.
+For each path matched by `paths`, the conditions are resolved with that path's placeholders and evaluated independently. A failed gate skips every `must` and `mustNot` predicate or block for that path. A match continues with normal predicate execution, including each block's own conditions and `for` behavior. A use-site `if` or `ifNot` replaces the corresponding inherited condition as one complete object rather than merging condition properties.
 
 This top-level form is specific to reusable-convention references; hand-written conventions continue to put conditions inside `must` blocks. See [Reusable conventions](./reusable-conventions.md).
+
+## Positive and negative gates
+
+`if` and `ifNot` accept exactly the same condition object. Both use the same condition evaluator; `ifNot` reverses its result rather than defining a separate list of predicates. Adding support for a condition automatically makes it available through both fields.
+
+| Fields present | The rule runs when |
+| --- | --- |
+| neither | Always. |
+| `if` | `if` matches. |
+| `ifNot` | `ifNot` does not match. |
+| both | `if` matches and `ifNot` does not match. |
 
 ## Object form vs. array form
 
@@ -65,6 +77,7 @@ Switch from object to array form when you need:
   "name": "test-render-helper",
   "description": "Component test files must use the project's custom render helper",
   "if": { "hasFile": "index.test.tsx" },
+  "ifNot": { "hasFile": "skip-tests.ts" },
   "for": { "files": "index.test.tsx" },
   "excludeFiles": ["components/legacy/**"],
   "must": { "importValues": [{ "name": "render", "from": "@/test-utils" }] },
@@ -77,14 +90,19 @@ Switch from object to array form when you need:
 | `must` | `MustPredicates` | yes, unless `mustNot` is present | The predicates this block enforces. See [predicates.md](./predicates.md). |
 | `mustNot` | `MustPredicates` | yes, unless `must` is present | The predicates this block forbids. |
 | `if` | condition object | no | Gate. Block runs only if one supported condition holds. |
+| `ifNot` | condition object | no | Negative gate. Block runs only if the condition does not hold. |
 | `for` | `{ files: string \| string[] }` | no | Scope. Predicates apply to files matching this pattern within the parent path. |
 | `excludeFiles` | `string[]` | no | Glob patterns to exclude from the block. |
 | `name` | string matching `[a-z0-9-]+` | no | Identifier shown in violation reports. |
 | `description` | string | no | Human-readable explanation. |
 
-## `if.hasFile`
+## Condition predicates for `if` and `ifNot`
 
-The condition matches only when the named file exists at (or relative to) the matched path. Templates are resolved using the matched path's placeholders.
+Every predicate in this section is available through both `if` and `ifNot`. The predicate determines whether the condition matches; the containing field determines whether that result is used directly or reversed.
+
+### `hasFile`
+
+The condition matches only when the named file exists at (or relative to) the matched path. Templates are resolved using the matched path's placeholders. Use the same object under `ifNot` to run only when the file is absent.
 
 ```json
 {
@@ -101,11 +119,11 @@ The condition matches only when the named file exists at (or relative to) the ma
 
 For `components/Button`, the block runs only if `components/Button/index.test.tsx` exists. Components without test files are skipped — no false-positive "missing export" violations.
 
-## `if.placeholderSatisfies`
+### `placeholderSatisfies`
 
-The condition matches only when the named placeholder satisfies a constraint. Syntax, constraint catalog, and examples are in [constraints.md](./constraints.md#ifplaceholdersatisfies).
+The condition matches only when the named placeholder satisfies a constraint. Under `ifNot`, the gate passes when the placeholder does not satisfy it. Syntax, constraint catalog, and examples are in [constraints.md](./constraints.md#matchesregex).
 
-## Import conditions
+### Import predicates
 
 Import conditions inspect the file at the matched `paths` entry. They return false when the matched path is a directory. A block-level condition runs before `for.files`, so it always inspects the parent matched path rather than files selected by `for`. Parsing is shared with block conditions and TypeScript predicates for the same file.
 
@@ -149,7 +167,7 @@ Value and type imports remain separate:
 
 Only static ES import declarations count. Re-exports, dynamic `import()`, `require()`, and TypeScript import-equals do not.
 
-An `if` condition has exactly **one** condition property — not multiple and not an empty object.
+Each `if` or `ifNot` condition has exactly **one** condition property — not multiple and not an empty object.
 
 ## `for.files`
 
@@ -187,7 +205,7 @@ For `components/Button`, the block runs once per `*.stories.tsx` file inside `Bu
 }
 ```
 
-### Combining `if` and `for`
+### Combining conditions and `for`
 
 ```json
 {
@@ -197,7 +215,7 @@ For `components/Button`, the block runs once per `*.stories.tsx` file inside `Bu
 }
 ```
 
-`if` gates whether the block runs at all; `for` narrows which files inside the matched path the predicates apply to. Common idiom: gate on the existence of a file, then run predicates only on that file.
+`if` and `ifNot` gate whether the block runs at all; `for` narrows which files inside the matched path the predicates apply to. Common idiom: gate on the existence of a file, then run predicates only on that file.
 
 ## `excludeFiles`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,7 +61,7 @@ A convention is a rule that says "files matching `paths` must satisfy `must` and
 
 The configuration is `strict` — unknown fields cause a validation error. Run `konsistent validate` to catch typos.
 
-Hand-written conventions do not accept a top-level `if`. Top-level `if` is available on reusable-convention string and object references: an inherited or use-site condition gates the entire expanded convention for each matched path. See [Top-level conditions on reusable references](./conditional-rules.md#top-level-conditions-on-reusable-references).
+Hand-written conventions do not accept top-level `if` or `ifNot`. Both are available on reusable-convention string and object references: inherited or use-site conditions gate the entire expanded convention for each matched path. See [Top-level conditions on reusable references](./conditional-rules.md#top-level-conditions-on-reusable-references).
 
 ## `must`: predicates or blocks
 
@@ -92,7 +92,7 @@ All listed predicates apply unconditionally to every matched path. See [predicat
 ]
 ```
 
-Each entry is a `MustBlock` that can have `if`, `for`, `excludeFiles`, `name`, and `description`. See [conditional-rules.md](./conditional-rules.md). An entry may alternatively be a reusable-convention reference of the form `{ "use": "<vendor>/<name>", ...overrides }`, which expands into a `MustBlock` — see [reusable-conventions.md](./reusable-conventions.md#use-inside-a-parents-must).
+Each entry is a `MustBlock` that can have `if`, `ifNot`, `for`, `excludeFiles`, `name`, and `description`. See [conditional-rules.md](./conditional-rules.md). An entry may alternatively be a reusable-convention reference of the form `{ "use": "<vendor>/<name>", ...overrides }`, which expands into a `MustBlock` — see [reusable-conventions.md](./reusable-conventions.md#use-inside-a-parents-must).
 
 ## `mustNot`: negated predicates
 

--- a/docs/reference/constraints.md
+++ b/docs/reference/constraints.md
@@ -3,7 +3,7 @@
 Constraints filter which placeholder values a rule applies to. They appear in two places:
 
 1. **Inline path constraints** — `paths: "packages/{providerId:matches(^[a-z]+ai$)}"`. Captured paths whose value fails the constraint are skipped.
-2. **`if.placeholderSatisfies`** — gates a `must` block on the placeholder's value (see [conditional-rules.md](./conditional-rules.md)).
+2. **`if.placeholderSatisfies` or `ifNot.placeholderSatisfies`** — gates a rule on the placeholder's value (see [conditional-rules.md](./conditional-rules.md)).
 
 Both contexts use the same `name:constraint(arg)` syntax.
 
@@ -31,7 +31,7 @@ The placeholder value must match the JavaScript regex. Case-sensitive. The patte
 
 Only providers whose ID ends in `ai` (e.g., `openai`, `mistralai`) are considered. The rule does not apply to `google`, `anthropic`, etc.
 
-### `if.placeholderSatisfies`
+### `placeholderSatisfies` with `matches(regex)`
 
 ```json
 {
@@ -46,7 +46,7 @@ Only providers whose ID ends in `ai` (e.g., `openai`, `mistralai`) are considere
 }
 ```
 
-The base rule (`src/index.ts` required) applies to every package. The conditional block (`src/${providerId}-stem.ts` required) applies only when `providerId` matches the regex.
+The base rule (`src/index.ts` required) applies to every package. The conditional block (`src/${providerId}-stem.ts` required) applies only when `providerId` matches the regex. Put the same `placeholderSatisfies` object under `ifNot` to apply a block only when the value does not match.
 
 ## `segments(n)`
 
@@ -92,7 +92,7 @@ chat_language           → 2 segments
 
 The first block matches files like `chat-language-model.ts` (2-segment `modelKind`); the second matches `embedding-model.ts` (1-segment `modelKind`). Different `must` predicates apply to each shape.
 
-### `if.placeholderSatisfies`
+### `placeholderSatisfies` with `segments(n)`
 
 ```json
 {
@@ -106,7 +106,7 @@ The first block matches files like `chat-language-model.ts` (2-segment `modelKin
 - The argument inside `(...)` is taken **verbatim** — no quotes around regexes or numbers.
 - The argument may **not contain `}`**. If you need a regex quantifier, use repetition: `\d\d?` instead of `\d{1,2}`.
 - Constraints apply to placeholder **values** (`{...}`) and to `placeholderSatisfies` arguments. They do not apply to template substitutions (`${...}`).
-- An `if` block has exactly one condition property (see [conditional-rules.md](./conditional-rules.md)).
+- Each `if` or `ifNot` object has exactly one condition property (see [conditional-rules.md](./conditional-rules.md)).
 
 ## Difference from path negation
 

--- a/docs/reference/predicates.md
+++ b/docs/reference/predicates.md
@@ -655,6 +655,6 @@ Multiple predicates in the same `must` are AND-ed:
 }
 ```
 
-For OR-style logic (apply different predicates to different files), use [conditional rules](./conditional-rules.md) — the array form of `must` with `if`/`for` blocks.
+For OR-style logic (apply different predicates to different files), use [conditional rules](./conditional-rules.md) — the array form of `must` with `if`/`ifNot`/`for` blocks.
 
 Note that **reusable conventions** (those published via `@konsistent/convention` and consumed via `conventionSources`) are restricted to flat object-form `must` and `mustNot` predicates — the `MustBlock[]` form is unavailable on the author side. Hand-written conventions in your own `konsistent.json` can still use `MustBlock[]` in `must`. See [reusable-conventions.md](./reusable-conventions.md#restrictions).

--- a/docs/reference/reusable-conventions.md
+++ b/docs/reference/reusable-conventions.md
@@ -43,7 +43,7 @@ Each entry of `conventions[]` is one of three shapes. The first two are new for 
 
 ### String reference
 
-A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. The reusable convention must declare its own `paths` — string references cannot supply them. If the convention has no `paths`, `konsistent` fails at config load and tells you to switch to the `use` form. An inherited `if` condition is also preserved and evaluated for each path matched by the reusable convention.
+A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. The reusable convention must declare its own `paths` — string references cannot supply them. If the convention has no `paths`, `konsistent` fails at config load and tells you to switch to the `use` form. Inherited `if` and `ifNot` conditions are also preserved and evaluated for each path matched by the reusable convention.
 
 ```json
 {
@@ -59,7 +59,7 @@ A bare string `"<vendor>/<name>"` inlines the named reusable convention as-is. T
 
 ### Object reference (`use` form)
 
-`{ "use": "<vendor>/<name>", ...overrides }` references a reusable convention and overlays your overrides on top of it. The top-level override fields are `paths`, `placeholders`, `excludeFiles`, `severity`, `if`, `must`, and `mustNot`; `name` and `description` come from the source. `for` is only available when the reference appears inside a parent's `must[]`.
+`{ "use": "<vendor>/<name>", ...overrides }` references a reusable convention and overlays your overrides on top of it. The top-level override fields are `paths`, `placeholders`, `excludeFiles`, `severity`, `if`, `ifNot`, `must`, and `mustNot`; `name` and `description` come from the source. `for` is only available when the reference appears inside a parent's `must[]`.
 
 Use this form when the reusable convention has no `paths` (so you must supply them) or when you want to adjust a field for your project.
 
@@ -94,17 +94,18 @@ When a reusable convention's `must` references a placeholder (e.g. `${providerId
 
 See [Static placeholder values](./path-patterns.md#static-placeholder-values) for the full rules.
 
-An `if` declared by the reusable convention is inherited by both string and object references. An object reference can replace it with a project-specific condition:
+`if` and `ifNot` declared by the reusable convention are inherited by both string and object references. An object reference can replace either with a project-specific condition:
 
 ```json
 {
   "use": "common/conditionally-require-tests",
   "paths": "packages/{packageName}",
-  "if": { "hasFile": "${packageName}.spec.ts" }
+  "if": { "hasFile": "${packageName}.spec.ts" },
+  "ifNot": { "hasFile": "skip-tests.ts" }
 }
 ```
 
-The condition is evaluated separately for every matched path. A non-match skips the expanded convention's complete `must` and `mustNot` work for that path. A match continues into its predicates and any block-level conditions. See [Conditional rules](./conditional-rules.md#top-level-conditions-on-reusable-references).
+The conditions are evaluated separately for every matched path. A failed gate skips the expanded convention's complete `must` and `mustNot` work for that path. A match continues into its predicates and any block-level conditions. See [Conditional rules](./conditional-rules.md#top-level-conditions-on-reusable-references).
 
 ### Hand-written convention
 
@@ -133,7 +134,7 @@ A hand-written convention whose `must` is a `MustBlock[]` may also reference a r
 }
 ```
 
-Allowed override keys at this nesting level are every field a hand-written `MustBlock` exposes — `name`, `description`, `if`, `for`, `excludeFiles`, `must`, and `mustNot`. Top-level-only fields (`paths`, `severity`) are not accepted at the use-site, and the referenced reusable convention must not declare them either: a reusable that ships `paths` or `severity` can only be referenced from the top level of `conventions[]`. Authors who want their reusable to be usable in both contexts should publish it without those fields.
+Allowed override keys at this nesting level are every field a hand-written `MustBlock` exposes — `name`, `description`, `if`, `ifNot`, `for`, `excludeFiles`, `must`, and `mustNot`. Top-level-only fields (`paths`, `severity`) are not accepted at the use-site, and the referenced reusable convention must not declare them either: a reusable that ships `paths` or `severity` can only be referenced from the top level of `conventions[]`. Authors who want their reusable to be usable in both contexts should publish it without those fields.
 
 Override merge follows the same rules as the top-level `use` form: arrays and conditions replace, primitives replace, and `must`/`mustNot` deep-merge with the inherited predicates.
 
@@ -144,7 +145,7 @@ When you write `{ use: "<vendor>/<name>", ...overrides }`, `konsistent` deep-mer
 | Field kind | Rule |
 | --- | --- |
 | Plain object (e.g. `must`, `mustNot`, nested predicate definitions) | Recursive deep-merge. Keys you supply replace the inherited value; keys you omit pass through. |
-| `if` condition object | The complete use-site condition replaces the inherited condition. Condition properties are never combined. |
+| `if` or `ifNot` condition object | The complete use-site condition replaces the corresponding inherited condition. The two fields remain independent, and condition properties are never combined. |
 | Array (e.g. `paths`, `excludeFiles`, predicate lists like `haveFiles`, `declareFunctions`, `exportValues`, `exportFunctions`) | Your array fully replaces the inherited array. Use `"excludeFiles": []` to clear an inherited list. |
 | Primitive (e.g. `severity`, `description`) | Your value replaces the inherited value. |
 
@@ -205,7 +206,7 @@ Note that `excludeFiles` was fully replaced (array-replace), while `must` was de
 
 ## Placeholder validation
 
-After expansion, `konsistent` walks every string inside each merged convention's `if`, `must`, and `mustNot` and checks that each `${placeholder}` referenced is declared as `{placeholder}` in at least one `paths` entry or in `placeholders`. This includes inherited and overridden conditions, and catches mismatches before any file is scanned.
+After expansion, `konsistent` walks every string inside each merged convention's `if`, `ifNot`, `must`, and `mustNot` and checks that each `${placeholder}` referenced is declared as `{placeholder}` in at least one `paths` entry or in `placeholders`. This includes inherited and overridden conditions, and catches mismatches before any file is scanned.
 
 ## Error reference
 
@@ -223,7 +224,7 @@ All errors below are returned from `loadConfig()` as `{ success: false, error }`
 | npm source missing exports condition | `Convention source "<prefix>" → "<specifier>": package does not declare an exports["./konsistent"] entry.` | The source package isn't a reusable-convention package; check the spelling or pick a different source. |
 | Reusable-convention package fails schema validation | `Convention source "<prefix>" → "<specifier>": invalid reusable-convention package at <path>: <issues>` | The author shipped an invalid package; report upstream. |
 | Empty source value | `Convention source "<prefix>" has empty value.` | Supply a path or npm specifier. |
-| Placeholder used in `if`, `must`, or `mustNot` but not declared in `paths` or `placeholders` | `Convention "<identifier>" references "${<placeholder>}" in <key>, but neither paths nor placeholders declare "{<placeholder>}".` | Either declare the placeholder in `paths` or `placeholders`, or remove the unresolved template. |
+| Placeholder used in `if`, `ifNot`, `must`, or `mustNot` but not declared in `paths` or `placeholders` | `Convention "<identifier>" references "${<placeholder>}" in <key>, but neither paths nor placeholders declare "{<placeholder>}".` | Either declare the placeholder in `paths` or `placeholders`, or remove the unresolved template. |
 | `use` inside `must[]` points at a reusable that declares `paths`/`severity` | `Convention "<prefix>/<name>" referenced in conventions[<i>].must[<j>] declares top-level-only field(s) "<field>". Such conventions can only be referenced at the top level of conventions[]. Either remove the field(s) from the source convention, or move the reference out of must[].` | Drop `paths`/`severity` from the reusable, or reference it directly from `conventions[]`. |
 
 `<identifier>` in the placeholder error is the convention's `name`, the `<vendor>/<name>` reference, or `conventions[<i>]` — whichever was available.
@@ -232,4 +233,4 @@ All errors below are returned from `loadConfig()` as `{ success: false, error }`
 
 - [Authoring reusable conventions](../guides/authoring-reusable-conventions.md) — publish your own.
 - [konsistent.json reference](./configuration.md) — the surrounding config shape.
-- [Path patterns](./path-patterns.md) — placeholder syntax used in `paths`, `if`, `must`, and `mustNot`.
+- [Path patterns](./path-patterns.md) — placeholder syntax used in `paths`, `if`, `ifNot`, `must`, and `mustNot`.

--- a/e2e/fixtures/import-conditions/konsistent.json
+++ b/e2e/fixtures/import-conditions/konsistent.json
@@ -36,6 +36,38 @@
           "must": { "exportConstants": ["typeImportFromConditionPassed"] }
         }
       ]
+    },
+    {
+      "name": "negative-import-conditions",
+      "paths": "src/matching.ts",
+      "must": [
+        {
+          "ifNot": {
+            "hasValueImport": {
+              "name": "createClient",
+              "from": "./dependencies"
+            }
+          },
+          "must": { "exportConstants": ["unexpectedValueCondition"] }
+        },
+        {
+          "ifNot": {
+            "hasTypeImport": {
+              "name": "Client",
+              "from": "./dependencies"
+            }
+          },
+          "must": { "exportConstants": ["unexpectedTypeCondition"] }
+        },
+        {
+          "ifNot": { "hasValueImportFrom": "./side-effect" },
+          "must": { "exportConstants": ["unexpectedValueSourceCondition"] }
+        },
+        {
+          "ifNot": { "hasTypeImportFrom": "./dependencies" },
+          "must": { "exportConstants": ["unexpectedTypeSourceCondition"] }
+        }
+      ]
     }
   ]
 }

--- a/e2e/fixtures/placeholder-satisfies/konsistent.json
+++ b/e2e/fixtures/placeholder-satisfies/konsistent.json
@@ -9,6 +9,12 @@
         {
           "if": { "placeholderSatisfies": "providerId:matches(^[a-z]+ai$)" },
           "must": { "haveFiles": ["src/${providerId}-stem.ts"] }
+        },
+        {
+          "ifNot": {
+            "placeholderSatisfies": "providerId:matches(^[a-z]+ai$)"
+          },
+          "must": { "haveFiles": ["src/non-ai.ts"] }
         }
       ]
     }

--- a/e2e/fixtures/placeholder-satisfies/packages/google/src/non-ai.ts
+++ b/e2e/fixtures/placeholder-satisfies/packages/google/src/non-ai.ts
@@ -1,0 +1,1 @@
+export const nonAi = true;

--- a/e2e/fixtures/reusable-convention-top-level-if/konsistent.json
+++ b/e2e/fixtures/reusable-convention-top-level-if/konsistent.json
@@ -6,7 +6,9 @@
   "conventions": [
     {
       "use": "common/conditionally-require-file",
-      "if": { "hasFile": "gate.ts" }
-    }
+      "if": { "hasFile": "gate.ts" },
+      "ifNot": { "hasFile": "skip.ts" }
+    },
+    "common/conditionally-require-file"
   ]
 }

--- a/e2e/fixtures/reusable-convention-top-level-if/local-conventions.json
+++ b/e2e/fixtures/reusable-convention-top-level-if/local-conventions.json
@@ -6,6 +6,7 @@
       "description": "Matching directories must contain required.ts.",
       "paths": "src/{caseName}",
       "if": { "hasFile": "inherited-gate.ts" },
+      "ifNot": { "hasFile": "inherited-skip.ts" },
       "must": {
         "haveFiles": ["required.ts"]
       }

--- a/e2e/fixtures/reusable-convention-top-level-if/src/inherited-negated/inherited-gate.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/inherited-negated/inherited-gate.ts
@@ -1,0 +1,1 @@
+export const inheritedGate = true;

--- a/e2e/fixtures/reusable-convention-top-level-if/src/inherited-negated/inherited-skip.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/inherited-negated/inherited-skip.ts
@@ -1,0 +1,1 @@
+export const inheritedSkip = true;

--- a/e2e/fixtures/reusable-convention-top-level-if/src/negated/gate.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/negated/gate.ts
@@ -1,0 +1,1 @@
+export const gate = true;

--- a/e2e/fixtures/reusable-convention-top-level-if/src/negated/skip.ts
+++ b/e2e/fixtures/reusable-convention-top-level-if/src/negated/skip.ts
@@ -1,0 +1,1 @@
+export const skip = true;

--- a/e2e/reusable-conventions.test.ts
+++ b/e2e/reusable-conventions.test.ts
@@ -97,7 +97,7 @@ describe("reusable-convention-object-ref-broken fixture", () => {
 describe("reusable-convention-top-level-if fixture", () => {
   const cwd = resolve(fixturesDir, "reusable-convention-top-level-if");
 
-  it("runs a matching top-level use condition and skips non-matching paths", async () => {
+  it("combines inherited and overridden top-level if and ifNot conditions", async () => {
     try {
       await runCli({ args: ["check"], cwd });
       expect.fail("Expected check to exit with code 1");
@@ -112,12 +112,14 @@ describe("reusable-convention-top-level-if fixture", () => {
       expect(error.stdout).toContain("Missing required file");
       expect(error.stdout).toContain("required.ts");
       expect(error.stdout).toContain("src/matching");
-      expect(error.stdout).not.toContain("src/skipped");
-      expect(error.stdout).toContain("Found 1 error.");
+      expect(error.stdout).toContain("src/skipped");
+      expect(error.stdout).not.toContain("src/negated");
+      expect(error.stdout).not.toContain("src/inherited-negated");
+      expect(error.stdout).toContain("Found 2 errors.");
     }
   });
 
-  it("validates the top-level condition override", async () => {
+  it("validates top-level condition overrides", async () => {
     const { stdout } = await runCli({ args: ["validate"], cwd });
     expect(stdout).toContain("Configuration is valid");
   });

--- a/packages/convention/reusable-convention-package.schema.json
+++ b/packages/convention/reusable-convention-package.schema.json
@@ -141,6 +141,104 @@
                   }
                 ]
               },
+              "ifNot": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasFile": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasFile"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "placeholderSatisfies": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["placeholderSatisfies"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["hasValueImport"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasValueImportFrom"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["hasTypeImport"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasTypeImportFrom"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
               "for": {
                 "type": "object",
                 "properties": {
@@ -2397,6 +2495,104 @@
                 }
               },
               "if": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasFile": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasFile"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "placeholderSatisfies": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["placeholderSatisfies"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["hasValueImport"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasValueImportFrom"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": ["hasTypeImport"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hasTypeImportFrom"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "ifNot": {
                 "anyOf": [
                   {
                     "type": "object",

--- a/packages/convention/src/generated-schema.test.ts
+++ b/packages/convention/src/generated-schema.test.ts
@@ -130,7 +130,7 @@ describe("reusable-convention-package.schema.json", () => {
     expect(valid).toBe(true);
   });
 
-  it("accepts value and type import conditions", () => {
+  it("accepts value and type import conditions through if and ifNot", () => {
     const conditions = [
       { hasValueImport: { name: "createClient", from: "./client" } },
       { hasValueImportFrom: "./client" },
@@ -138,19 +138,21 @@ describe("reusable-convention-package.schema.json", () => {
       { hasTypeImportFrom: "./client" },
     ];
 
-    for (const [index, condition] of conditions.entries()) {
-      const valid = validate({
-        conventionSpecVersion: "v1",
-        conventions: [
-          {
-            name: `import-condition-${index}`,
-            description: "Import condition.",
-            if: condition,
-            must: { haveType: "file" },
-          },
-        ],
-      });
-      expect(valid).toBe(true);
+    for (const conditionField of ["if", "ifNot"]) {
+      for (const [index, condition] of conditions.entries()) {
+        const valid = validate({
+          conventionSpecVersion: "v1",
+          conventions: [
+            {
+              name: `import-condition-${index}`,
+              description: "Import condition.",
+              [conditionField]: condition,
+              must: { haveType: "file" },
+            },
+          ],
+        });
+        expect(valid).toBe(true);
+      }
     }
   });
 

--- a/packages/convention/src/index.test.ts
+++ b/packages/convention/src/index.test.ts
@@ -14,7 +14,7 @@ describe("ReusableConventionV1Schema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts optional paths, excludeFiles, severity, if, for", () => {
+  it("accepts optional paths, excludeFiles, severity, if, ifNot, for", () => {
     const result = ReusableConventionV1Schema.safeParse({
       name: "files-must-export-default",
       description: "Component files must export default.",
@@ -22,6 +22,7 @@ describe("ReusableConventionV1Schema", () => {
       excludeFiles: ["**/*.test.ts"],
       severity: "warning",
       if: { hasFile: "${name}.ts" },
+      ifNot: { placeholderSatisfies: "name:segments(2)" },
       for: { files: "${name}.ts" },
       must: { exportValues: ["default"] },
     });

--- a/packages/convention/src/schemas.test.ts
+++ b/packages/convention/src/schemas.test.ts
@@ -132,6 +132,7 @@ describe("predicate and block schemas", () => {
       MustBlockV1Schema.safeParse({
         name: "required-export",
         if: { hasFile: "index.ts" },
+        ifNot: { placeholderSatisfies: "name:segments(2)" },
         for: { files: "index.ts" },
         must: { exportValues: ["createClient"] },
       }).success

--- a/packages/convention/src/schemas.ts
+++ b/packages/convention/src/schemas.ts
@@ -208,6 +208,7 @@ const MustBlockV1Shape = {
     .optional(),
   description: z.string().optional(),
   if: IfConditionV1Schema.optional(),
+  ifNot: IfConditionV1Schema.optional(),
   for: z
     .strictObject({ files: z.union([z.string(), z.array(z.string())]) })
     .optional(),
@@ -236,6 +237,7 @@ const ReusableConventionV1Shape = {
   paths: z.union([z.string(), z.array(z.string())]).optional(),
   excludeFiles: z.array(z.string()).optional(),
   if: IfConditionV1Schema.optional(),
+  ifNot: IfConditionV1Schema.optional(),
   for: z
     .strictObject({ files: z.union([z.string(), z.array(z.string())]) })
     .optional(),

--- a/packages/konsistent/konsistent.schema.json
+++ b/packages/konsistent/konsistent.schema.json
@@ -203,6 +203,120 @@
                   }
                 ]
               },
+              "ifNot": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasFile": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "hasFile"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "placeholderSatisfies": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "placeholderSatisfies"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "hasValueImport"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasValueImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "hasValueImportFrom"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImport": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "from": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "hasTypeImport"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "hasTypeImportFrom": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "hasTypeImportFrom"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
               "for": {
                 "type": "object",
                 "properties": {
@@ -4038,6 +4152,120 @@
                                         }
                                       ]
                                     },
+                                    "ifNot": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasFile": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasFile"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "placeholderSatisfies": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
                                     "for": {
                                       "type": "object",
                                       "properties": {
@@ -6497,6 +6725,120 @@
                                       "type": "string"
                                     },
                                     "if": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasFile": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasFile"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "placeholderSatisfies": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "ifNot": {
                                       "anyOf": [
                                         {
                                           "type": "object",
@@ -9075,6 +9417,120 @@
                                   "type": "string"
                                 },
                                 "if": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasFile": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasFile"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "placeholderSatisfies": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "placeholderSatisfies"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasValueImport": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "from": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "hasValueImport"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasValueImportFrom": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasValueImportFrom"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasTypeImport": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "from": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "hasTypeImport"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasTypeImportFrom": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasTypeImportFrom"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "ifNot": {
                                   "anyOf": [
                                     {
                                       "type": "object",
@@ -14246,6 +14702,120 @@
                                         }
                                       ]
                                     },
+                                    "ifNot": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasFile": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasFile"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "placeholderSatisfies": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
                                     "for": {
                                       "type": "object",
                                       "properties": {
@@ -16705,6 +17275,120 @@
                                       "type": "string"
                                     },
                                     "if": {
+                                      "anyOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasFile": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasFile"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "placeholderSatisfies": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "placeholderSatisfies"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasValueImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasValueImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImport": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "from": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImport"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "hasTypeImportFrom": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "hasTypeImportFrom"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "ifNot": {
                                       "anyOf": [
                                         {
                                           "type": "object",
@@ -19283,6 +19967,120 @@
                                   "type": "string"
                                 },
                                 "if": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasFile": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasFile"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "placeholderSatisfies": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "placeholderSatisfies"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasValueImport": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "from": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "hasValueImport"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasValueImportFrom": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasValueImportFrom"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasTypeImport": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "from": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "name"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "hasTypeImport"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "hasTypeImportFrom": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "hasTypeImportFrom"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "ifNot": {
                                   "anyOf": [
                                     {
                                       "type": "object",

--- a/packages/konsistent/scripts/generate-schema.test.ts
+++ b/packages/konsistent/scripts/generate-schema.test.ts
@@ -106,7 +106,7 @@ describe("konsistent.schema.json", () => {
     expect(mustNotSchema.type).toBe("object");
   });
 
-  it("accepts value and type import conditions", () => {
+  it("accepts value and type import conditions through if and ifNot", () => {
     const conditions = [
       { hasValueImport: { name: "createClient", from: "./client" } },
       { hasValueImportFrom: "./client" },
@@ -118,10 +118,10 @@ describe("konsistent.schema.json", () => {
       conventions: [
         {
           paths: "src/index.ts",
-          must: conditions.map((condition) => ({
-            if: condition,
-            must: { haveType: "file" },
-          })),
+          must: conditions.flatMap((condition) => [
+            { if: condition, must: { haveType: "file" } },
+            { ifNot: condition, must: { haveType: "file" } },
+          ]),
         },
       ],
     });
@@ -137,6 +137,7 @@ describe("konsistent.schema.json", () => {
           use: "common/conditional-rule",
           paths: "src/*.ts",
           if: { hasFile: "test.ts" },
+          ifNot: { placeholderSatisfies: "name:segments(2)" },
         },
       ],
     });

--- a/packages/konsistent/src/config/placeholder-validator.test.ts
+++ b/packages/konsistent/src/config/placeholder-validator.test.ts
@@ -335,6 +335,33 @@ describe("validatePlaceholders", () => {
     }
   });
 
+  it("reports placeholders inside top-level and block ifNot conditions", () => {
+    const conventions: ConventionV1[] = [
+      {
+        name: "negative-conditions",
+        paths: ["packages/{packageName}/index.ts"],
+        ifNot: { hasFile: "${missingTopLevel}.ts" },
+        must: [
+          {
+            ifNot: { hasValueImportFrom: "${missingBlockSource}" },
+            must: { haveType: "file" },
+          },
+        ],
+      },
+    ];
+
+    const result = validatePlaceholders({
+      conventions,
+      identifiers: ["negative-conditions"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("ifNot.hasFile");
+      expect(result.error).toContain("must.ifNot.hasValueImportFrom");
+    }
+  });
+
   it("reports placeholders inside for.files (string and array form)", () => {
     const stringForm: ConventionV1[] = [
       {

--- a/packages/konsistent/src/config/placeholder-validator.ts
+++ b/packages/konsistent/src/config/placeholder-validator.ts
@@ -97,7 +97,15 @@ function collectUsagesInConvention(opts: {
   if (convention.if) {
     collectUsagesInCondition({
       condition: convention.if,
-      prefix: "",
+      keyPrefix: "if",
+      declared,
+      usages,
+    });
+  }
+  if (convention.ifNot) {
+    collectUsagesInCondition({
+      condition: convention.ifNot,
+      keyPrefix: "ifNot",
       declared,
       usages,
     });
@@ -114,12 +122,11 @@ function collectUsagesInConvention(opts: {
 
 function collectUsagesInCondition(opts: {
   condition: IfConditionV1;
-  prefix: string;
+  keyPrefix: string;
   declared: Set<string>;
   usages: Usage[];
 }): void {
-  const { condition, prefix, declared, usages } = opts;
-  const keyPrefix = prefix ? `${prefix}.if` : "if";
+  const { condition, keyPrefix, declared, usages } = opts;
   if (Object.hasOwn(condition, "hasFile")) {
     pushStringUsages({
       value: (condition as { hasFile: string }).hasFile,
@@ -235,7 +242,15 @@ function collectUsagesInBlock(opts: {
   if (block.if) {
     collectUsagesInCondition({
       condition: block.if,
-      prefix: "must",
+      keyPrefix: "must.if",
+      declared: declaredHere,
+      usages,
+    });
+  }
+  if (block.ifNot) {
+    collectUsagesInCondition({
+      condition: block.ifNot,
+      keyPrefix: "must.ifNot",
       declared: declaredHere,
       usages,
     });

--- a/packages/konsistent/src/config/reference-expander.test.ts
+++ b/packages/konsistent/src/config/reference-expander.test.ts
@@ -80,6 +80,7 @@ describe("expandReferences", () => {
           description: "Runs only for matching packages.",
           paths: "packages/{packageName}",
           if: { hasFile: "${packageName}.test.ts" },
+          ifNot: { hasFile: "${packageName}.skip.ts" },
           must: { haveFiles: ["index.ts"] },
         },
       ],
@@ -94,6 +95,9 @@ describe("expandReferences", () => {
     if (result.success) {
       expect(result.conventions[0]?.if).toEqual({
         hasFile: "${packageName}.test.ts",
+      });
+      expect(result.conventions[0]?.ifNot).toEqual({
+        hasFile: "${packageName}.skip.ts",
       });
     }
   });
@@ -311,6 +315,7 @@ describe("expandReferences", () => {
           name: "conditional-object",
           description: "Runs only when a marker exists.",
           if: { hasFile: "marker.ts" },
+          ifNot: { hasFile: "skip.ts" },
           must: { haveFiles: ["index.ts"] },
         },
       ],
@@ -329,6 +334,7 @@ describe("expandReferences", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.conventions[0]?.if).toEqual({ hasFile: "marker.ts" });
+      expect(result.conventions[0]?.ifNot).toEqual({ hasFile: "skip.ts" });
     }
   });
 
@@ -340,6 +346,7 @@ describe("expandReferences", () => {
           description: "Uses a consumer-specific gate.",
           paths: "packages/{packageName}",
           if: { hasFile: "inherited-marker.ts" },
+          ifNot: { hasFile: "inherited-skip.ts" },
           must: { haveFiles: ["index.ts"] },
         },
       ],
@@ -362,6 +369,46 @@ describe("expandReferences", () => {
       expect(result.conventions[0]?.if).toEqual({
         placeholderSatisfies: "packageName:matches(^public-)",
       });
+      expect(result.conventions[0]?.ifNot).toEqual({
+        hasFile: "inherited-skip.ts",
+      });
+    }
+  });
+
+  it("replaces an inherited ifNot condition independently", () => {
+    const sourceMap = buildSourceMap({
+      common: [
+        {
+          name: "negative-condition-override",
+          description: "Uses a consumer-specific negative gate.",
+          paths: "packages/{packageName}",
+          if: { hasFile: "required-marker.ts" },
+          ifNot: { hasFile: "inherited-skip.ts" },
+          must: { haveFiles: ["index.ts"] },
+        },
+      ],
+    });
+
+    const result = expandReferences({
+      conventions: [
+        {
+          use: "common/negative-condition-override",
+          ifNot: {
+            placeholderSatisfies: "packageName:matches(^internal-)",
+          },
+        },
+      ],
+      sourceMap,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.conventions[0]?.if).toEqual({
+        hasFile: "required-marker.ts",
+      });
+      expect(result.conventions[0]?.ifNot).toEqual({
+        placeholderSatisfies: "packageName:matches(^internal-)",
+      });
     }
   });
 
@@ -373,6 +420,7 @@ describe("expandReferences", () => {
           description: "Uses condition placeholders.",
           paths: "packages/*",
           if: { hasFile: "${missingInherited}.ts" },
+          ifNot: { hasFile: "${missingInheritedNegative}.ts" },
           must: { haveFiles: ["index.ts"] },
         },
       ],
@@ -384,6 +432,7 @@ describe("expandReferences", () => {
         {
           use: "common/conditional-placeholders",
           if: { hasValueImportFrom: "${missingOverride}" },
+          ifNot: { hasTypeImportFrom: "${missingOverrideNegative}" },
         },
       ],
       sourceMap,
@@ -403,6 +452,12 @@ describe("expandReferences", () => {
         );
         expect(validationResult.error).toContain(
           'references "${missingOverride}" in if.hasValueImportFrom'
+        );
+        expect(validationResult.error).toContain(
+          'references "${missingInheritedNegative}" in ifNot.hasFile'
+        );
+        expect(validationResult.error).toContain(
+          'references "${missingOverrideNegative}" in ifNot.hasTypeImportFrom'
         );
       }
     }
@@ -834,6 +889,7 @@ describe("expandReferences", () => {
           name: "conditional-block",
           description: "Conditionally requires an index.",
           if: { hasFile: "inherited-marker.ts" },
+          ifNot: { hasFile: "inherited-skip.ts" },
           must: { haveFiles: ["index.ts"] },
         },
       ],
@@ -860,9 +916,11 @@ describe("expandReferences", () => {
       const must = result.conventions[0]?.must;
       if (Array.isArray(must)) {
         expect(must[0]?.if).toEqual({ hasFile: "inherited-marker.ts" });
+        expect(must[0]?.ifNot).toEqual({ hasFile: "inherited-skip.ts" });
         expect(must[1]?.if).toEqual({
           placeholderSatisfies: "packageName:segments(1)",
         });
+        expect(must[1]?.ifNot).toEqual({ hasFile: "inherited-skip.ts" });
       }
     }
   });

--- a/packages/konsistent/src/config/reference-expander.ts
+++ b/packages/konsistent/src/config/reference-expander.ts
@@ -9,6 +9,7 @@ import { ConventionV1Schema } from "./schema.js";
 import type { SourceMap } from "./source-resolver.js";
 
 const STRING_REF_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/;
+const CONDITION_FIELDS = ["if", "ifNot"] as const;
 
 export type ExpandReferencesResult =
   | { success: true; conventions: ConventionV1[]; identifiers: string[] }
@@ -190,9 +191,7 @@ function expandMustBlockReference(opts: {
   if (reusable.description !== undefined) {
     base.description = reusable.description;
   }
-  if (reusable.if !== undefined) {
-    base.if = reusable.if;
-  }
+  copyConditionFields({ from: reusable, to: base });
   if (reusable.for !== undefined) {
     base.for = reusable.for;
   }
@@ -301,9 +300,7 @@ function expandStringReference(opts: {
   if (reusable.excludeFiles !== undefined) {
     candidate.excludeFiles = reusable.excludeFiles;
   }
-  if (reusable.if !== undefined) {
-    candidate.if = reusable.if;
-  }
+  copyConditionFields({ from: reusable, to: candidate });
 
   const validated = ConventionV1Schema.safeParse(candidate);
   if (!validated.success) {
@@ -365,9 +362,7 @@ function expandUseReference(opts: {
   if (reusable.excludeFiles !== undefined) {
     base.excludeFiles = reusable.excludeFiles;
   }
-  if (reusable.if !== undefined) {
-    base.if = reusable.if;
-  }
+  copyConditionFields({ from: reusable, to: base });
 
   const merged = mergeReferenceOverrides({ base, overrides });
 
@@ -403,10 +398,24 @@ function mergeReferenceOverrides(opts: {
 }): Record<string, unknown> {
   const { base, overrides } = opts;
   const merged = deepMerge({ base, override: overrides });
-  if (Object.hasOwn(overrides, "if")) {
-    merged.if = overrides.if;
+  for (const field of CONDITION_FIELDS) {
+    if (Object.hasOwn(overrides, field)) {
+      merged[field] = overrides[field];
+    }
   }
   return merged;
+}
+
+function copyConditionFields(opts: {
+  from: { if?: unknown; ifNot?: unknown };
+  to: Record<string, unknown>;
+}): void {
+  const { from, to } = opts;
+  for (const field of CONDITION_FIELDS) {
+    if (from[field] !== undefined) {
+      to[field] = from[field];
+    }
+  }
 }
 
 function deepMerge(opts: {

--- a/packages/konsistent/src/config/schema.test.ts
+++ b/packages/konsistent/src/config/schema.test.ts
@@ -34,25 +34,43 @@ describe("ConfigV1Schema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("keeps top-level conditions unavailable to hand-written conventions", () => {
+  it("accepts a negative condition on a top-level use reference", () => {
     const result = ConfigV1Schema.safeParse({
       version: "v1",
       conventions: [
         {
+          use: "common/conditional-rule",
           paths: "src/*.ts",
-          if: { hasFile: "test.ts" },
-          must: { haveType: "file" },
+          ifNot: { hasFile: "test.ts" },
         },
       ],
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
-  it("accepts a top-level condition in the resolved convention schema", () => {
+  it("keeps top-level conditions unavailable to hand-written conventions", () => {
+    for (const conditionField of ["if", "ifNot"]) {
+      const result = ConfigV1Schema.safeParse({
+        version: "v1",
+        conventions: [
+          {
+            paths: "src/*.ts",
+            [conditionField]: { hasFile: "test.ts" },
+            must: { haveType: "file" },
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it("accepts top-level conditions in the resolved convention schema", () => {
     const result = ConventionV1Schema.safeParse({
       paths: "src/*.ts",
       if: { hasFile: "test.ts" },
+      ifNot: { placeholderSatisfies: "name:segments(2)" },
       must: { haveType: "file" },
     });
 
@@ -517,7 +535,7 @@ describe("ConfigV1Schema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts a MustBlock with both if and for fields", () => {
+  it("accepts a MustBlock with if, ifNot, and for fields", () => {
     const result = ConfigV1Schema.safeParse({
       version: "v1",
       conventions: [
@@ -526,6 +544,7 @@ describe("ConfigV1Schema", () => {
           must: [
             {
               if: { hasFile: "${name}.test.tsx" },
+              ifNot: { placeholderSatisfies: "name:segments(2)" },
               for: { files: "${name}.test.tsx" },
               must: { exportValues: ["describe"] },
             },
@@ -561,17 +580,24 @@ describe("ConfigV1Schema", () => {
     { hasTypeImport: "Client" },
     { hasTypeImport: { name: "Client", from: "./client" } },
     { hasTypeImportFrom: "./client" },
-  ])("accepts a MustBlock with an import condition", (condition) => {
-    const result = ConfigV1Schema.safeParse({
-      version: "v1",
-      conventions: [
-        {
-          paths: "src/*.ts",
-          must: [{ if: condition, must: { haveType: "file" } }],
-        },
-      ],
-    });
-    expect(result.success).toBe(true);
+  ])("accepts a MustBlock import condition through if and ifNot", (condition) => {
+    for (const conditionField of ["if", "ifNot"]) {
+      const result = ConfigV1Schema.safeParse({
+        version: "v1",
+        conventions: [
+          {
+            paths: "src/*.ts",
+            must: [
+              {
+                [conditionField]: condition,
+                must: { haveType: "file" },
+              },
+            ],
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    }
   });
 
   it("rejects alias configuration in an import condition", () => {

--- a/packages/konsistent/src/config/schema.ts
+++ b/packages/konsistent/src/config/schema.ts
@@ -84,6 +84,7 @@ const ConventionV1Shape = {
   paths: z.union([z.string(), z.array(z.string())]),
   placeholders: PlaceholdersMapSchema.optional(),
   if: IfConditionV1Schema.optional(),
+  ifNot: IfConditionV1Schema.optional(),
 };
 
 export const ConventionV1Schema = z.union([
@@ -112,6 +113,7 @@ export const MustBlockUseRefSchema = z.strictObject({
     .optional(),
   description: z.string().optional(),
   if: IfConditionV1Schema.optional(),
+  ifNot: IfConditionV1Schema.optional(),
   for: ForSchema.optional(),
   excludeFiles: z.array(z.string()).optional(),
   must: MustPredicatesV1Schema.optional(),
@@ -173,6 +175,7 @@ export const ConventionUseRefSchema = z.strictObject({
   placeholders: PlaceholdersMapSchema.optional(),
   excludeFiles: z.array(z.string()).optional(),
   if: IfConditionV1Schema.optional(),
+  ifNot: IfConditionV1Schema.optional(),
   for: ForSchema.optional(),
   must: MustPredicatesV1Schema.optional(),
   mustNot: MustPredicatesV1Schema.optional(),

--- a/packages/konsistent/src/core/runner.test.ts
+++ b/packages/konsistent/src/core/runner.test.ts
@@ -26,6 +26,22 @@ function createMockFileSystem(opts: {
   };
 }
 
+function createMatchingConditions(): IfConditionV1[] {
+  return [
+    { hasFile: "marker.ts" },
+    { placeholderSatisfies: "moduleName:matches(^client$)" },
+    {
+      hasValueImport: {
+        name: "create${moduleName.toPascalCase()}",
+        from: "./${moduleName}",
+      },
+    },
+    { hasValueImportFrom: "./${moduleName}" },
+    { hasTypeImport: { name: "${moduleName.toPascalCase()}" } },
+    { hasTypeImportFrom: "./${moduleName}" },
+  ];
+}
+
 describe("run", () => {
   it("bounds ancestor conventions and nested file blocks to selected paths", async () => {
     const config: ConfigV1 = {
@@ -1123,27 +1139,23 @@ describe("run", () => {
   });
 
   it("supports every condition at the top level and reuses parsed files", async () => {
-    const conditions: IfConditionV1[] = [
-      { hasFile: "marker.ts" },
-      { placeholderSatisfies: "moduleName:matches(^client$)" },
-      {
-        hasValueImport: {
-          name: "create${moduleName.toPascalCase()}",
-          from: "./${moduleName}",
-        },
-      },
-      { hasValueImportFrom: "./${moduleName}" },
-      { hasTypeImport: { name: "${moduleName.toPascalCase()}" } },
-      { hasTypeImportFrom: "./${moduleName}" },
-    ];
+    const conditions = createMatchingConditions();
     const config: ConfigV1 = {
       version: "v1",
-      conventions: conditions.map((condition, index) => ({
-        name: `top-level-condition-${index}`,
-        paths: "src/{moduleName}.ts",
-        if: condition,
-        must: { exportConstants: [`missing${index}`] },
-      })),
+      conventions: conditions.flatMap((condition, index) => [
+        {
+          name: `top-level-condition-${index}`,
+          paths: "src/{moduleName}.ts",
+          if: condition,
+          must: { exportConstants: [`missing${index}`] },
+        },
+        {
+          name: `top-level-negative-condition-${index}`,
+          paths: "src/{moduleName}.ts",
+          ifNot: condition,
+          must: { exportConstants: [`missingNegative${index}`] },
+        },
+      ]),
     };
     const fs = createMockFileSystem({
       globResults: new Map([["src/*.ts", ["src/client.ts"]]]),
@@ -1160,7 +1172,135 @@ describe("run", () => {
     const { diagnostics } = await run({ config, fileSystem: fs });
 
     expect(diagnostics).toHaveLength(conditions.length);
+    expect(diagnostics.map((diagnostic) => diagnostic.conventionName)).toEqual(
+      conditions.map((_, index) => `top-level-condition-${index}`)
+    );
     expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports every condition through ifNot in nested blocks", async () => {
+    const conditions = createMatchingConditions();
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          name: "nested-conditions",
+          paths: "src/{moduleName}.ts",
+          must: conditions.flatMap((condition, index) => [
+            {
+              name: `positive-condition-${index}`,
+              if: condition,
+              must: { exportConstants: [`missing${index}`] },
+            },
+            {
+              name: `negative-condition-${index}`,
+              ifNot: condition,
+              must: { exportConstants: [`missingNegative${index}`] },
+            },
+          ]),
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/*.ts", ["src/client.ts"]]]),
+      files: new Set(["src/client.ts", "src/marker.ts"]),
+      fileContents: new Map([
+        [
+          "src/client.ts",
+          'import { createClient, type Client } from "./client";',
+        ],
+      ]),
+    });
+    const readSpy = vi.spyOn(fs, "readFile");
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+
+    expect(diagnostics).toHaveLength(conditions.length);
+    expect(diagnostics.map((diagnostic) => diagnostic.conventionName)).toEqual(
+      conditions.map((_, index) => `positive-condition-${index}`)
+    );
+    expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("combines if and ifNot gates at the top level and in nested blocks", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          name: "top-level-runs",
+          paths: "src/index.ts",
+          if: { hasFile: "marker.ts" },
+          ifNot: { hasFile: "skip.ts" },
+          must: { haveType: "directory" },
+        },
+        {
+          name: "top-level-skips",
+          paths: "src/index.ts",
+          if: { hasFile: "marker.ts" },
+          ifNot: { hasFile: "marker.ts" },
+          must: { haveType: "directory" },
+        },
+        {
+          name: "nested-gates",
+          paths: "src/index.ts",
+          must: [
+            {
+              name: "nested-runs",
+              if: { hasFile: "marker.ts" },
+              ifNot: { hasFile: "skip.ts" },
+              must: { haveType: "directory" },
+            },
+            {
+              name: "nested-skips",
+              if: { hasFile: "marker.ts" },
+              ifNot: { hasFile: "marker.ts" },
+              must: { haveType: "directory" },
+            },
+          ],
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/index.ts", ["src/index.ts"]]]),
+      files: new Set(["src/index.ts", "src/marker.ts"]),
+    });
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.conventionName)).toEqual([
+      "top-level-runs",
+      "nested-runs",
+    ]);
+  });
+
+  it("exactly inverts non-matching placeholder and directory import conditions", async () => {
+    const config: ConfigV1 = {
+      version: "v1",
+      conventions: [
+        {
+          name: "negative-edge-cases",
+          paths: "src/module",
+          ifNot: { placeholderSatisfies: "unknown:matches(" },
+          must: [
+            {
+              ifNot: { hasValueImportFrom: "pkg" },
+              must: { haveType: "file" },
+            },
+          ],
+        },
+      ],
+    };
+    const fs = createMockFileSystem({
+      globResults: new Map([["src/module", ["src/module"]]]),
+      directories: new Set(["src/module"]),
+    });
+    const readSpy = vi.spyOn(fs, "readFile");
+
+    const { diagnostics } = await run({ config, fileSystem: fs });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.conventionName).toBe("negative-edge-cases");
+    expect(readSpy).not.toHaveBeenCalled();
   });
 
   it("skips import conditions when the matched path is a directory", async () => {

--- a/packages/konsistent/src/core/runner.ts
+++ b/packages/konsistent/src/core/runner.ts
@@ -239,15 +239,12 @@ function evaluatePlaceholderSatisfies(opts: {
 }
 
 function evaluateCondition(opts: {
-  condition: IfConditionV1 | undefined;
+  condition: IfConditionV1;
   context: PredicateContext;
   fileSystem: FileSystem;
   fileStructureCache: Map<string, FileStructure>;
 }): boolean {
   const { condition, context, fileSystem, fileStructureCache } = opts;
-  if (!condition) {
-    return true;
-  }
   if (Object.hasOwn(condition, "hasFile")) {
     const resolvedPath = context.resolveTemplate(
       (condition as { hasFile: string }).hasFile
@@ -303,6 +300,45 @@ function evaluateCondition(opts: {
     context,
     fileStructure,
   });
+}
+
+function evaluateConditions(opts: {
+  ifCondition?: IfConditionV1;
+  ifNotCondition?: IfConditionV1;
+  context: PredicateContext;
+  fileSystem: FileSystem;
+  fileStructureCache: Map<string, FileStructure>;
+}): boolean {
+  const {
+    ifCondition,
+    ifNotCondition,
+    context,
+    fileSystem,
+    fileStructureCache,
+  } = opts;
+  if (
+    ifCondition &&
+    !evaluateCondition({
+      condition: ifCondition,
+      context,
+      fileSystem,
+      fileStructureCache,
+    })
+  ) {
+    return false;
+  }
+  if (
+    ifNotCondition &&
+    evaluateCondition({
+      condition: ifNotCondition,
+      context,
+      fileSystem,
+      fileStructureCache,
+    })
+  ) {
+    return false;
+  }
+  return true;
 }
 
 const TS_PREDICATE_HANDLERS: Record<
@@ -1379,8 +1415,9 @@ export async function run(opts: {
       }
 
       if (
-        !evaluateCondition({
-          condition: convention.if,
+        !evaluateConditions({
+          ifCondition: convention.if,
+          ifNotCondition: convention.ifNot,
           context,
           fileSystem,
           fileStructureCache,
@@ -1391,8 +1428,9 @@ export async function run(opts: {
 
       for (const block of blocks) {
         if (
-          !evaluateCondition({
-            condition: block.if,
+          !evaluateConditions({
+            ifCondition: block.if,
+            ifNotCondition: block.ifNot,
             context,
             fileSystem,
             fileStructureCache,


### PR DESCRIPTION
## Pull Request Description

Adds `ifNot` as a negative conditional gate everywhere `if` is supported, including nested `must` blocks and top-level reusable convention references.

An `ifNot` gate applies a rule when its condition does not match. When both `if` and `ifNot` are present, the rule runs only when the `if` condition matches and the `ifNot` condition does not.

## Relevant technical choices

- Uses the same schema and evaluator for `if` and `ifNot`, so every current and future `if` predicate is supported by `ifNot` by definition.
- Preserves `ifNot` through reusable convention expansion, inheritance, and use-site overrides, with placeholder validation matching `if`.
- Updates generated schemas, unit tests, end-to-end fixtures, reference documentation, and guides for the new negative gate.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)
