### PR TITLE
fix broken release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: changesets/action
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: changesets/action
+        update-types:
+          - version-update:semver-major
     groups:
       actions:
         patterns:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         if: inputs.snapshot != true
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm ci:version
           publish: pnpm ci:release


### PR DESCRIPTION
## Pull Request Description

#88 broke the `release.yml` workflow by updating the changeset action to its next major, which is incompatible with the changeset CLI version used.

## Relevant technical choices

Revert back to the latest compatible version and block dependabot from applying major updates to this action.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated
- [ ] A changeset has been added (run `pnpm changeset` in the project root if package files were modified)
- [x] I have reviewed this pull request (self-review)